### PR TITLE
fix: tab completion - custom completers for config set/get key - value

### DIFF
--- a/src/fabric_cli/commands/config/fab_config_get.py
+++ b/src/fabric_cli/commands/config/fab_config_get.py
@@ -10,8 +10,8 @@ from fabric_cli.utils import fab_ui as utils_ui
 
 
 def exec_command(args: Namespace) -> None:
-    key = _normalize_key(args.key.lower())
-    if key not in fab_constant.CONFIG_KEYS:
+    key = fab_state_config.normalize_config_key(args.key.lower())
+    if key not in fab_constant.FAB_CONFIG_KEYS_TO_VALID_VALUES:
         raise FabricCLIError(
             ErrorMessages.Config.unknown_configuration_key(key),
             fab_constant.ERROR_INVALID_INPUT,
@@ -20,13 +20,3 @@ def exec_command(args: Namespace) -> None:
         value = fab_state_config.get_config(key)
         if value:
             utils_ui.print_output_format(args, data=value)
-
-
-def _normalize_key(key: str) -> str:
-    """
-    Removes the 'fab_' prefix from the key if it exists.
-    Otherwise returns the original key.
-    """
-    if key.startswith("fab_"):
-        return key[4:]
-    return key

--- a/src/fabric_cli/commands/config/fab_config_ls.py
+++ b/src/fabric_cli/commands/config/fab_config_ls.py
@@ -12,7 +12,7 @@ def exec_command(args: Namespace) -> None:
 
     all_configs = [
         {"setting": key, "value": configs.get(key, "")}
-        for key in fab_constant.CONFIG_KEYS
+        for key in fab_constant.FAB_CONFIG_KEYS_TO_VALID_VALUES
     ]
 
     columns = ["setting", "value"]

--- a/src/fabric_cli/core/completers/__init__.py
+++ b/src/fabric_cli/core/completers/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/src/fabric_cli/core/completers/fab_config_completers.py
+++ b/src/fabric_cli/core/completers/fab_config_completers.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from argparse import Namespace
+from typing import List
+
+from fabric_cli.core import fab_constant, fab_state_config
+
+
+def complete_config_keys(prefix: str, **kwargs) -> List[str]:
+    keys = list(fab_constant.FAB_CONFIG_KEYS_TO_VALID_VALUES.keys())
+    normalized_prefix = fab_state_config.normalize_config_key(prefix.lower())
+    matching_keys = [key for key in keys if key.lower().startswith(normalized_prefix)]
+
+    if prefix.lower().startswith("fab_"):
+        matching_keys.extend(
+            [f"fab_{key}" for key in keys if key.lower().startswith(normalized_prefix)]
+        )
+
+    return sorted(list(set(matching_keys)))
+
+
+def complete_config_values(prefix: str, parsed_args: Namespace, **kwargs) -> List[str]:
+    if not hasattr(parsed_args, "key") or not parsed_args.key:
+        return []
+
+    key = fab_state_config.normalize_config_key(parsed_args.key.lower())
+
+    if key not in fab_constant.FAB_CONFIG_KEYS_TO_VALID_VALUES:
+        return []
+
+    valid_values = fab_constant.FAB_CONFIG_KEYS_TO_VALID_VALUES[key]
+
+    if not valid_values:
+        return []
+
+    matching_values = [
+        value for value in valid_values if value.lower().startswith(prefix.lower())
+    ]
+
+    return sorted(matching_values)

--- a/src/fabric_cli/core/fab_constant.py
+++ b/src/fabric_cli/core/fab_constant.py
@@ -92,7 +92,7 @@ FAB_OUTPUT_FORMAT = "output_format"
 FAB_FOLDER_LISTING_ENABLED = "folder_listing_enabled"
 FAB_WS_PRIVATE_LINKS_ENABLED = "workspace_private_links_enabled"
 
-CONFIG_KEYS = {
+FAB_CONFIG_KEYS_TO_VALID_VALUES = {
     FAB_CACHE_ENABLED: ["false", "true"],
     FAB_CONTEXT_PERSISTENCE_ENABLED: ["false", "true"],
     FAB_DEBUG_ENABLED: ["false", "true"],
@@ -208,9 +208,7 @@ WARNING_DIFFERENT_ITEM_TYPES = "Different item types, review"
 WARNING_INVALID_PATHS = (
     "Source and destination must be of the same type. Check your paths"
 )
-WARNING_NOT_SUPPORTED_PATHS = (
-    "mv is not supported for the specified source and destination items types. Check your paths"
-)
+WARNING_NOT_SUPPORTED_PATHS = "mv is not supported for the specified source and destination items types. Check your paths"
 WARNING_INVALID_SPECIAL_CHARACTERS = (
     "Special caracters not supported for this item type"
 )

--- a/src/fabric_cli/core/fab_state_config.py
+++ b/src/fabric_cli/core/fab_state_config.py
@@ -14,7 +14,9 @@ def config_location():
         os.makedirs(_location)
     return _location
 
+
 config_file = os.path.join(config_location(), "config.json")
+
 
 def read_config(file_path) -> dict:
     try:
@@ -53,7 +55,7 @@ def init_defaults():
     """
     current_config = read_config(config_file)
 
-    for key in fab_constant.CONFIG_KEYS:
+    for key in fab_constant.FAB_CONFIG_KEYS_TO_VALID_VALUES:
         old_key = f"fab_{key}"
         if old_key in current_config:
             # Transfer value if not already set under the new key
@@ -64,3 +66,9 @@ def init_defaults():
             current_config[key] = fab_constant.CONFIG_DEFAULT_VALUES[key]
 
     write_config(current_config)
+
+
+def normalize_config_key(key: str) -> str:
+    if key.startswith("fab_"):
+        return key[4:]
+    return key

--- a/src/fabric_cli/parsers/fab_config_parser.py
+++ b/src/fabric_cli/parsers/fab_config_parser.py
@@ -5,6 +5,7 @@ from argparse import Namespace, _SubParsersAction
 
 from fabric_cli.commands.config import fab_config as config
 from fabric_cli.core import fab_constant
+from fabric_cli.core.completers import fab_config_completers
 from fabric_cli.utils import fab_error_parser as utils_error_parser
 from fabric_cli.utils import fab_ui as utils_ui
 from fabric_cli.utils.fab_util import get_os_specific_command
@@ -40,8 +41,16 @@ def register_parser(subparsers: _SubParsersAction) -> None:
         fab_examples=set_examples,
         fab_learnmore=["_"],
     )
-    parser_set.add_argument("key", metavar="<key>", help="Configuration key")
-    parser_set.add_argument("value", metavar="<value>", help="Configuration value")
+
+    # Add completer to key argument
+    key_arg = parser_set.add_argument("key", metavar="<key>", help="Configuration key")
+    key_arg.completer = fab_config_completers.complete_config_keys
+
+    # Add completer to value argument
+    value_arg = parser_set.add_argument(
+        "value", metavar="<value>", help="Configuration value"
+    )
+    value_arg.completer = fab_config_completers.complete_config_values
 
     parser_set.usage = f"{utils_error_parser.get_usage_prog(parser_set)}"
     parser_set.set_defaults(func=config.set_config)
@@ -60,7 +69,12 @@ def register_parser(subparsers: _SubParsersAction) -> None:
         fab_examples=get_examples,
         fab_learnmore=["_"],
     )
-    parser_get.add_argument("key", metavar="<key>", help="Configuration key")
+
+    # Add completer to key argument
+    get_key_arg = parser_get.add_argument(
+        "key", metavar="<key>", help="Configuration key"
+    )
+    get_key_arg.completer = fab_config_completers.complete_config_keys
 
     parser_get.usage = f"{utils_error_parser.get_usage_prog(parser_get)}"
     parser_get.set_defaults(func=config.get_config)

--- a/tests/test_commands/test_config.py
+++ b/tests/test_commands/test_config.py
@@ -40,7 +40,11 @@ class TestConfig:
         assert test_data.capacity.name in call_args[0]
 
     def test_config_set_default_capacity_invalid_capacity_failure(
-        self, mock_print_done, assert_fabric_cli_error, cli_executor: CLIExecutor, test_data: StaticTestData
+        self,
+        mock_print_done,
+        assert_fabric_cli_error,
+        cli_executor: CLIExecutor,
+        test_data: StaticTestData,
     ):
         capacity_name = test_data.capacity.name + "?"
         expected_message = ErrorMessages.Config.invalid_capacity(capacity_name)
@@ -147,7 +151,7 @@ class TestConfig:
         cli_executor.exec_command("config ls")
 
         # Assert
-        for key in constant.CONFIG_KEYS:
+        for key in constant.FAB_CONFIG_KEYS_TO_VALID_VALUES:
             assert any(
                 key in call.args[0] for call in mock_questionary_print.mock_calls
             )

--- a/tests/test_core/test_fab_config_completers.py
+++ b/tests/test_core/test_fab_config_completers.py
@@ -1,0 +1,83 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from argparse import Namespace
+from unittest.mock import patch
+
+from fabric_cli.core import fab_constant
+from fabric_cli.core.completers import fab_config_completers
+
+
+def test_complete_config_keys_returns_all_keys_when_no_prefix():
+    with patch(
+        "fabric_cli.core.completers.fab_config_completers.sorted"
+    ) as mock_sorted:
+        mock_sorted.side_effect = lambda x: x
+
+        result = fab_config_completers.complete_config_keys("")
+
+        mock_sorted.assert_called_once()
+
+        expected_keys = list(fab_constant.FAB_CONFIG_KEYS_TO_VALID_VALUES.keys())
+        assert set(result) == set(expected_keys)
+
+
+def test_complete_config_keys_filters_by_prefix():
+    result = fab_config_completers.complete_config_keys("mode")
+    assert "mode" in result
+
+    result = fab_config_completers.complete_config_keys("default")
+    assert len(result) > 0
+    for key in result:
+        assert key.startswith("default")
+
+
+def test_complete_config_keys_case_insensitive():
+    result_lower = fab_config_completers.complete_config_keys("mode")
+    result_upper = fab_config_completers.complete_config_keys("MODE")
+
+    assert result_lower == result_upper
+
+
+def test_complete_config_values_enum_keys():
+    args = Namespace()
+    args.key = "mode"
+
+    result = fab_config_completers.complete_config_values("", args)
+    assert result == ["command_line", "interactive"]
+
+    result = fab_config_completers.complete_config_values("inter", args)
+    assert result == ["interactive"]
+
+
+def test_complete_config_values_invalid_key():
+    args = Namespace()
+    args.key = "invalid_key_that_does_not_exist"
+
+    result = fab_config_completers.complete_config_values("", args)
+    assert result == []
+
+
+def test_complete_config_values_empty_key():
+    args = Namespace()
+    args.key = ""
+
+    result = fab_config_completers.complete_config_values("", args)
+    assert result == []
+
+
+def test_complete_config_values_default_capacity():
+    args = Namespace()
+    args.key = "default_capacity"
+
+    result = fab_config_completers.complete_config_values("", args)
+
+    assert result == []
+
+
+def test_complete_config_keys_with_fab_prefix():
+    result_with_fab = fab_config_completers.complete_config_keys("fab_mode")
+    result_without_fab = fab_config_completers.complete_config_keys("mode")
+
+    assert "mode" in result_with_fab
+    assert "mode" in result_without_fab


### PR DESCRIPTION
This pull request introduces improvements to the configuration handling in the CLI, focusing on standardizing configuration key/value management, adding shell completion support, and cleaning up related code. The main changes include replacing the old `CONFIG_KEYS` constant with a more descriptive `FAB_CONFIG_KEYS_TO_VALID_VALUES`, centralizing key normalization logic, and introducing argument completers for configuration commands. Tests have been added for the new completion logic.

**Configuration Key/Value Handling:**
- Replaced `CONFIG_KEYS` with `FAB_CONFIG_KEYS_TO_VALID_VALUES` throughout the codebase for better clarity and maintainability. This affects how valid configuration keys and their allowed values are checked in multiple files. [[1]](diffhunk://#diff-e8b046220ae44af8a1ee7c93bb9f844585b00f506a2ea7b262fae32387d661bdL13-R14) [[2]](diffhunk://#diff-cbc2d3d5bfa7412e67ff8ed1c8ec7defd8749fdca5d50ad92bf1972266082cffL15-R15) [[3]](diffhunk://#diff-f7fa488ab3965ec232dc10d6ac92fb6a61d04002892229b46fd95615a74e401bL18-R21) [[4]](diffhunk://#diff-f7fa488ab3965ec232dc10d6ac92fb6a61d04002892229b46fd95615a74e401bL36-L60) [[5]](diffhunk://#diff-7f668d994f2a6aca33cdc0fde940ea9b43f1866673e4291a692b6d14c559e981L95-R95) [[6]](diffhunk://#diff-3690fff9cfdbc6a10b26add4fb3c10db3c759001cab5bf7775a76f4fa9b69eb8L56-R58) [[7]](diffhunk://#diff-f6da8c0082330eb9f05e2caeb768ef91957ba048a7e7a5c9ea0e12f3eba7de53L150-R154)
- Centralized the normalization of configuration keys (removing the `fab_` prefix) into a single function `normalize_config_key` in `fab_state_config.py`, removing duplicated normalization logic from other modules. [[1]](diffhunk://#diff-e8b046220ae44af8a1ee7c93bb9f844585b00f506a2ea7b262fae32387d661bdL13-R14) [[2]](diffhunk://#diff-f7fa488ab3965ec232dc10d6ac92fb6a61d04002892229b46fd95615a74e401bL18-R21) [[3]](diffhunk://#diff-3690fff9cfdbc6a10b26add4fb3c10db3c759001cab5bf7775a76f4fa9b69eb8R69-R74)

**Shell Completion Support:**
- Added new completer functions `complete_config_keys` and `complete_config_values` in `fab_config_completers.py` to provide tab-completion for configuration keys and values in the CLI.
- Integrated these completers into the argument parsers for the `config set` and `config get` commands, enhancing user experience with shell completion. [[1]](diffhunk://#diff-210be4f806ef338c9d4d91168027aeda9e8edc9c31619c4354bb8e492aad2d46R8) [[2]](diffhunk://#diff-210be4f806ef338c9d4d91168027aeda9e8edc9c31619c4354bb8e492aad2d46L43-R53) [[3]](diffhunk://#diff-210be4f806ef338c9d4d91168027aeda9e8edc9c31619c4354bb8e492aad2d46L63-R77)

**Testing and Miscellaneous:**
- Added comprehensive unit tests for the new completer functions in `test_fab_config_completers.py`.
- Minor code formatting and copyright/license header additions. [[1]](diffhunk://#diff-e4724323cda510cf3676d53c00ba748dcc4724742e0edeb103cd86d158f3ab1dR1-R2) [[2]](diffhunk://#diff-f0fb4b925eb7eab546dede386d3d4aab7144f7bf7db5bb45b43f66748f9376d5R1-R41)
- Cleaned up and slightly reformatted some messages and code blocks for consistency (e.g., warning message formatting, minor whitespace changes). [[1]](diffhunk://#diff-7f668d994f2a6aca33cdc0fde940ea9b43f1866673e4291a692b6d14c559e981L211-R211) [[2]](diffhunk://#diff-3690fff9cfdbc6a10b26add4fb3c10db3c759001cab5bf7775a76f4fa9b69eb8R17-R20) [[3]](diffhunk://#diff-f7fa488ab3965ec232dc10d6ac92fb6a61d04002892229b46fd95615a74e401bL78-R70) [[4]](diffhunk://#diff-f6da8c0082330eb9f05e2caeb768ef91957ba048a7e7a5c9ea0e12f3eba7de53L43-R47)

These changes make the configuration system more robust, easier to maintain, and more user-friendly by leveraging shell completion and centralizing key logic.