### PR TITLE
ci: add semantic pull request title validation workflow

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,112 @@
+# Linter to enforce semantic pull request titles (see https://www.conventionalcommits.org/)
+---
+name: 🔍 Semantic PR Validation
+
+on:
+  pull_request:
+    branches: 
+      - main
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check_pr_title:
+    name: Check Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Semantic PR Validation
+        id: validation
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+            const regex = /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(\([^)]+\))?(!?): .+/;
+
+            if (!regex.test(prTitle)) {
+              core.setFailed('Pull request title does not follow Conventional Commits specification. See PR comment for details.');
+            }
+      - name: Handle Invalid Title
+        if: failure()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const commentMarker = '<!-- semantic-pr-comment -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existingComment = comments.find(comment => comment.body.includes(commentMarker));
+
+            if (!existingComment) {
+              const message = `<!-- semantic-pr-comment -->
+
+            Hey there and thank you for your contribution! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits](https://www.conventionalcommits.org/) specification and it looks like your proposed title needs to be adjusted.
+
+            A valid title has the format: \`type(scope): subject\`
+
+            **type**: Must be one of the following:
+              - \`feat\`: A new feature
+              - \`fix\`: A bug fix
+              - \`docs\`: Documentation only changes
+              - \`style\`: Changes that do not affect the meaning of the code (e.g., formatting)
+              - \`refactor\`: A code change that neither fixes a bug nor adds a feature
+              - \`perf\`: A code change that improves performance
+              - \`test\`: Adding missing tests or correcting existing tests
+              - \`chore\`: Changes to the build process or auxiliary tools
+              - \`build\`: Changes that affect the build system or external dependencies
+              - \`ci\`: Changes to CI configuration files and scripts
+              - \`revert\`: Reverts a previous commit
+
+            **scope** (optional): A noun describing a section of the codebase.
+
+            **subject**: A short description of the code changes.
+
+            Examples:
+              - \`feat(api): add new endpoint for users\`
+              - \`fix: correct a typo in the documentation\`
+              - \`docs(readme): update installation instructions\`
+
+            Please update your pull request title to match this format.`;
+
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: message
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['invalid']
+            });
+      - name: Handle Valid Title
+        if: success()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'invalid',
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   check_pr_title:

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -13,7 +13,7 @@ on:
       - ready_for_review
 
 permissions:
-  pull-requests: write
+  issues: write
 
 jobs:
   check_pr_title:

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -13,7 +13,6 @@ on:
       - ready_for_review
 
 permissions:
-  issues: write
   pull-requests: write
 
 jobs:
@@ -99,15 +98,19 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            try {
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const invalidLabel = labels.find(label => label.name === 'invalid');
+
+            if (invalidLabel) {
               await github.rest.issues.removeLabel({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name: 'invalid',
               });
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
             }


### PR DESCRIPTION
### 📜 Description

This pull request introduces a new GitHub Actions workflow to enforce semantic pull request titles, ensuring they adhere to the [Conventional Commits specification](https://www.conventionalcommits.org/).

### 🤖 Workflow Details

The new workflow, located at [`./.github/workflows/semantic-pr.yml`](./.github/workflows/semantic-pr.yml:1), performs the following actions:

-   **Triggers**: Runs automatically when a pull request is opened, edited, reopened, or marked as ready for review against the `main` branch.
-   **Validation**: It checks if the PR title follows the conventional commit format (e.g., `feat(scope): description`).
-   **Feedback**:
    -   ✅ If the title is **valid**, the check passes. If an `invalid` label exists from a previous failure, it is removed.
    -   ❌ If the title is **invalid**, the check fails, an `invalid` label is added to the PR, and a comment is posted to guide the contributor on how to fix their title. The comment is only posted once to avoid spamming.

### ✨ Why This Change?

-   **Consistency**: Enforces a consistent and readable git history.
-   **Automation**: Automates the process of changelog generation and version bumping in the future.
-   **Clarity**: Provides immediate feedback to contributors, improving the development experience.

What is looks like:

<img width="956" height="869" alt="image" src="https://github.com/user-attachments/assets/8a31fbe6-bd91-47fa-9b98-e417836f306c" />
