### PR TITLE
fix: Change output font color to white in json format

### DIFF
--- a/src/fabric_cli/utils/fab_ui.py
+++ b/src/fabric_cli/utils/fab_ui.py
@@ -425,7 +425,7 @@ def _print_simple_items(data: list[Any], to_stderr: bool) -> None:
 
 
 def _print_output_format_json(output_json: str) -> None:
-    print_grey(output_json, to_stderr=False)
+    _safe_print(output_json)
 
 
 def _print_error_format_json(output: str) -> None:


### PR DESCRIPTION
Issue: When using the JSON output format, the result is incorrectly displayed in grey instead of white.
Solution: This PR updates the print_output_format function to use _safe_print for JSON output, replacing print_grey to avoid applying the grey font color.