### PR TITLE
fix(folders): newly created item is not displaying when running ls in a folder path 

### DIFF
--- a/src/fabric_cli/utils/fab_mem_store.py
+++ b/src/fabric_cli/utils/fab_mem_store.py
@@ -438,8 +438,14 @@ def get_item_id(workspace: Workspace, name) -> str:
 
 
 def upsert_item_to_cache(item: Item) -> None:
-    # Due to dependent elements (e.g. SQLEndpoint for Lakehouse), we need to invalidate the cache
+    # Invalidate both item cache and folder cache to maintain consistency
+    # when creating items inside folders
     invalidate_item_cache(item.parent)
+    
+    # When creating an item inside a folder, we also need to invalidate
+    # the folder cache to ensure proper listing
+    if isinstance(item.parent, Folder):
+        invalidate_folder_cache(item.workspace)
 
 
 def invalidate_item_cache(workspace: Workspace) -> None:

--- a/src/fabric_cli/utils/fab_mem_store.py
+++ b/src/fabric_cli/utils/fab_mem_store.py
@@ -442,8 +442,6 @@ def upsert_item_to_cache(item: Item) -> None:
     # when creating items inside folders
     invalidate_item_cache(item.parent)
     
-    # When creating an item inside a folder, we also need to invalidate
-    # the folder cache to ensure proper listing
     if isinstance(item.parent, Folder):
         invalidate_folder_cache(item.workspace)
 

--- a/tests/test_commands/recordings/test_commands/test_mkdir/class_setup.yaml
+++ b/tests/test_commands/recordings/test_commands/test_mkdir/class_setup.yaml
@@ -11,12 +11,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.0.0 (None; Linux; x86_64; 5.15.167.4-microsoft-standard-WSL2)
+      - ms-fabric-cli/1.1.0 (None; Linux; x86_64; 6.6.87.2-microsoft-standard-WSL2)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
     body:
-      string: '{"value": [{"id": "94da8ea5-0bd6-4a9e-b717-5fdb482f4c71", "displayName":
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
         "My workspace", "description": "", "type": "Personal"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -26,15 +26,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '323'
+      - '786'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 03 Sep 2025 06:33:28 GMT
+      - Thu, 25 Sep 2025 09:13:42 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 76530f35-0363-4306-8fc5-49fedeafecb9
+      - 7eaee504-fac2-4c96-8e32-dbef7efe8bde
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -42,7 +42,7 @@ interactions:
       X-Frame-Options:
       - deny
       home-cluster-uri:
-      - https://wabi-west-europe-redirect.analysis.windows.net/
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
       request-redirected:
       - 'true'
     status:
@@ -60,12 +60,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.0.0 (None; Linux; x86_64; 5.15.167.4-microsoft-standard-WSL2)
+      - ms-fabric-cli/1.1.0 (None; Linux; x86_64; 6.6.87.2-microsoft-standard-WSL2)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
     body:
-      string: '{"value": [{"id": "94da8ea5-0bd6-4a9e-b717-5fdb482f4c71", "displayName":
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
         "My workspace", "description": "", "type": "Personal"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -75,15 +75,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '323'
+      - '786'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 03 Sep 2025 06:33:27 GMT
+      - Thu, 25 Sep 2025 09:13:43 GMT
       Pragma:
       - no-cache
       RequestId:
-      - a2954a47-63b1-49bb-b1c3-fee0ef7ba1a8
+      - 695ed7dd-2104-488c-b0c0-845f91a5ca01
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -91,7 +91,7 @@ interactions:
       X-Frame-Options:
       - deny
       home-cluster-uri:
-      - https://wabi-west-europe-redirect.analysis.windows.net/
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
       request-redirected:
       - 'true'
     status:
@@ -109,13 +109,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.0.0 (None; Linux; x86_64; 5.15.167.4-microsoft-standard-WSL2)
+      - ms-fabric-cli/1.1.0 (None; Linux; x86_64; 6.6.87.2-microsoft-standard-WSL2)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/capacities
   response:
     body:
       string: '{"value": [{"id": "00000000-0000-0000-0000-000000000004", "displayName":
-        "mocked_fabriccli_capacity_name", "sku": "F16", "region": "West Europe", "state":
+        "mocked_fabriccli_capacity_name", "sku": "F2", "region": "Central US", "state":
         "Active"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -125,15 +125,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '456'
+      - '271'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 03 Sep 2025 06:33:32 GMT
+      - Thu, 25 Sep 2025 09:13:47 GMT
       Pragma:
       - no-cache
       RequestId:
-      - c0ecb729-f0cb-4dbd-87a3-1e3b2354c2af
+      - 6d155373-03fd-4f34-8d94-0820e30d54b1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -141,7 +141,7 @@ interactions:
       X-Frame-Options:
       - deny
       home-cluster-uri:
-      - https://wabi-west-europe-redirect.analysis.windows.net/
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
       request-redirected:
       - 'true'
     status:
@@ -162,12 +162,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.0.0 (None; Linux; x86_64; 5.15.167.4-microsoft-standard-WSL2)
+      - ms-fabric-cli/1.1.0 (None; Linux; x86_64; 6.6.87.2-microsoft-standard-WSL2)
     method: POST
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
     body:
-      string: '{"id": "e90776ff-42ae-4f92-b45d-25c3d375832b", "displayName": "fabriccli_WorkspacePerTestclass_000001",
+      string: '{"id": "d37f35bf-4dce-4291-9812-477382595e4b", "displayName": "fabriccli_WorkspacePerTestclass_000001",
         "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}'
     headers:
       Access-Control-Expose-Headers:
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 03 Sep 2025 06:33:39 GMT
+      - Thu, 25 Sep 2025 09:13:55 GMT
       Location:
-      - https://api.fabric.microsoft.com/v1/workspaces/e90776ff-42ae-4f92-b45d-25c3d375832b
+      - https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b
       Pragma:
       - no-cache
       RequestId:
-      - b518d7a5-ed86-428d-bbc7-94cce4701531
+      - 9950b60b-464a-477d-a0ee-0c15c5cdf936
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -195,7 +195,7 @@ interactions:
       X-Frame-Options:
       - deny
       home-cluster-uri:
-      - https://wabi-west-europe-redirect.analysis.windows.net/
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
       request-redirected:
       - 'true'
     status:
@@ -213,13 +213,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.0.0 (mkdir; Linux; x86_64; 5.15.167.4-microsoft-standard-WSL2)
+      - ms-fabric-cli/1.1.0 (ls; Linux; x86_64; 6.6.87.2-microsoft-standard-WSL2)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
     body:
-      string: '{"value": [{"id": "94da8ea5-0bd6-4a9e-b717-5fdb482f4c71", "displayName":
-        "My workspace", "description": "", "type": "Personal"}, {"id": "e90776ff-42ae-4f92-b45d-25c3d375832b",
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "d37f35bf-4dce-4291-9812-477382595e4b",
         "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "Created
         by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
     headers:
@@ -230,15 +230,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '359'
+      - '820'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 03 Sep 2025 06:54:13 GMT
+      - Thu, 25 Sep 2025 09:14:33 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 5ae7cf4e-5365-4fe9-8e4a-1501cd69657c
+      - c1d25fd0-3982-4b9e-bf98-dc785f01a79d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -246,7 +246,7 @@ interactions:
       X-Frame-Options:
       - deny
       home-cluster-uri:
-      - https://wabi-west-europe-redirect.analysis.windows.net/
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
       request-redirected:
       - 'true'
     status:
@@ -264,9 +264,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.0.0 (mkdir; Linux; x86_64; 5.15.167.4-microsoft-standard-WSL2)
+      - ms-fabric-cli/1.1.0 (ls; Linux; x86_64; 6.6.87.2-microsoft-standard-WSL2)
     method: GET
-    uri: https://api.fabric.microsoft.com/v1/workspaces/e90776ff-42ae-4f92-b45d-25c3d375832b/items
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/items
   response:
     body:
       string: '{"value": []}'
@@ -282,11 +282,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 03 Sep 2025 06:54:13 GMT
+      - Thu, 25 Sep 2025 09:14:34 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 9845e1e3-97df-47b8-a41d-7b5688d8fec5
+      - 4faadd3b-1048-460e-9bc3-fc8be2360ac1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -294,7 +294,7 @@ interactions:
       X-Frame-Options:
       - deny
       home-cluster-uri:
-      - https://wabi-west-europe-redirect.analysis.windows.net/
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
       request-redirected:
       - 'true'
     status:
@@ -314,9 +314,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.0.0 (mkdir; Linux; x86_64; 5.15.167.4-microsoft-standard-WSL2)
+      - ms-fabric-cli/1.1.0 (ls; Linux; x86_64; 6.6.87.2-microsoft-standard-WSL2)
     method: DELETE
-    uri: https://api.fabric.microsoft.com/v1/workspaces/e90776ff-42ae-4f92-b45d-25c3d375832b
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b
   response:
     body:
       string: ''
@@ -332,11 +332,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Wed, 03 Sep 2025 06:54:14 GMT
+      - Thu, 25 Sep 2025 09:14:35 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 4521135a-5f5e-4968-94d7-d113fe5c35f1
+      - 5c18271d-3f2c-4a89-a672-d0707be7a579
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -344,7 +344,7 @@ interactions:
       X-Frame-Options:
       - deny
       home-cluster-uri:
-      - https://wabi-west-europe-redirect.analysis.windows.net/
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
       request-redirected:
       - 'true'
     status:

--- a/tests/test_commands/recordings/test_commands/test_mkdir/test_mkdir_item_in_folder_listing_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_mkdir/test_mkdir_item_in_folder_listing_success.yaml
@@ -1,0 +1,1202 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "d37f35bf-4dce-4291-9812-477382595e4b",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "Created
+        by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '820'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:13:56 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 3652d3a8-cfac-48f2-9dfd-5c849583c1e7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:13:57 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 079301dc-05c6-4d49-b715-1355221c459e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:13:57 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 4e6ad5dc-4b23-45d9-ae1b-6927bd9a8a74
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Created by fab", "displayName": "fabcli000001"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders
+  response:
+    body:
+      string: '{"id": "90959334-3fa8-4800-9ab7-124e5679e6a2", "displayName": "fabcli000001",
+        "workspaceId": "d37f35bf-4dce-4291-9812-477382595e4b"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:13:59 GMT
+      Location:
+      - https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders/90959334-3fa8-4800-9ab7-124e5679e6a2
+      Pragma:
+      - no-cache
+      RequestId:
+      - fcd9186c-8a1c-40e4-bd44-cbdbe8110734
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "d37f35bf-4dce-4291-9812-477382595e4b",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "Created
+        by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '820'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:00 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 7e5b29bf-18eb-463e-b29a-5bd424ab44c9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": [{"id": "90959334-3fa8-4800-9ab7-124e5679e6a2", "displayName":
+        "fabcli000001", "workspaceId": "d37f35bf-4dce-4291-9812-477382595e4b"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:00 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - b811439b-a1fa-4687-a91a-b326515e9500
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/items
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:01 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 9d8daa2d-bf61-497d-8337-28e36b07bf56
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/items
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:02 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 73d4a2c1-5f7d-4fda-b335-16729ae6a224
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Created by fab", "displayName": "fabcli000002", "type":
+      "Notebook", "folderId": "90959334-3fa8-4800-9ab7-124e5679e6a2", "definition":
+      {"parts": [{"path": "notebook-content.py", "payload": "IyBGYWJyaWMgbm90ZWJvb2sgc291cmNlCgojIE1FVEFEQVRBICoqKioqKioqKioqKioqKioqKioqCgojIE1FVEEgewojIE1FVEEgICAia2VybmVsX2luZm8iOiB7CiMgTUVUQSAgICAgIm5hbWUiOiAic3luYXBzZV9weXNwYXJrIgojIE1FVEEgICB9LAojIE1FVEEgICAiZGVwZW5kZW5jaWVzIjoge30KIyBNRVRBIH0KCiMgQ0VMTCAqKioqKioqKioqKioqKioqKioqKgoKIyBXZWxjb21lIHRvIHlvdXIgbmV3IG5vdGVib29rCiMgVHlwZSBoZXJlIGluIHRoZSBjZWxsIGVkaXRvciB0byBhZGQgY29kZSEKCgojIE1FVEFEQVRBICoqKioqKioqKioqKioqKioqKioqCgojIE1FVEEgewojIE1FVEEgICAibGFuZ3VhZ2UiOiAicHl0aG9uIiwKIyBNRVRBICAgImxhbmd1YWdlX2dyb3VwIjogInN5bmFwc2VfcHlzcGFyayIKIyBNRVRBIH0K",
+      "payloadType": "InlineBase64"}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '798'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/notebooks
+  response:
+    body:
+      string: 'null'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,ETag,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:04 GMT
+      ETag:
+      - '""'
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6d3bb9e7-d9ea-421c-875b-c0f4061008d7
+      Pragma:
+      - no-cache
+      RequestId:
+      - b5c340d9-e9d4-4643-bd0a-46060b3354c8
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+      x-ms-operation-id:
+      - 6d3bb9e7-d9ea-421c-875b-c0f4061008d7
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6d3bb9e7-d9ea-421c-875b-c0f4061008d7
+  response:
+    body:
+      string: '{"status": "Succeeded", "createdTimeUtc": "2025-09-25T09:14:03.9477589",
+        "lastUpdatedTimeUtc": "2025-09-25T09:14:05.7915094", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '131'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:25 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6d3bb9e7-d9ea-421c-875b-c0f4061008d7/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - cb5e96d0-3e9e-43e4-9d5c-415d547c0020
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - 6d3bb9e7-d9ea-421c-875b-c0f4061008d7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6d3bb9e7-d9ea-421c-875b-c0f4061008d7/result
+  response:
+    body:
+      string: '{"id": "d5b1ed2d-b57a-474d-b4a5-7606c421db31", "type": "Notebook",
+        "displayName": "fabcli000002", "description": "Created by fab", "workspaceId":
+        "d37f35bf-4dce-4291-9812-477382595e4b", "folderId": "90959334-3fa8-4800-9ab7-124e5679e6a2"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Sep 2025 09:14:25 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - d5d39c05-f8ae-4eb7-bffb-908c496d8d38
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "d37f35bf-4dce-4291-9812-477382595e4b",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "Created
+        by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '820'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:27 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 1997bae4-5913-488c-bc4e-5cbaec6e23b4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": [{"id": "90959334-3fa8-4800-9ab7-124e5679e6a2", "displayName":
+        "fabcli000001", "workspaceId": "d37f35bf-4dce-4291-9812-477382595e4b"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:27 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - aa226e77-67be-4751-a92b-824165b31a5c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/items
+  response:
+    body:
+      string: '{"value": [{"id": "d5b1ed2d-b57a-474d-b4a5-7606c421db31", "type": "Notebook",
+        "displayName": "fabcli000002", "description": "Created by fab", "workspaceId":
+        "d37f35bf-4dce-4291-9812-477382595e4b", "folderId": "90959334-3fa8-4800-9ab7-124e5679e6a2"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '209'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:27 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 7c22ebfd-5fc2-49b6-a0d0-f512c5f07eca
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": [{"id": "90959334-3fa8-4800-9ab7-124e5679e6a2", "displayName":
+        "fabcli000001", "workspaceId": "d37f35bf-4dce-4291-9812-477382595e4b"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:28 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 962b901e-7fff-4cd4-af60-ce5d0b7e5c0e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": [{"id": "90959334-3fa8-4800-9ab7-124e5679e6a2", "displayName":
+        "fabcli000001", "workspaceId": "d37f35bf-4dce-4291-9812-477382595e4b"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:28 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 50eddf1d-4d07-47e5-8783-807efaa90510
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "d37f35bf-4dce-4291-9812-477382595e4b",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "Created
+        by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '820'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:29 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 5364f3d0-4b45-42a5-b519-2e4b4082c92f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": [{"id": "90959334-3fa8-4800-9ab7-124e5679e6a2", "displayName":
+        "fabcli000001", "workspaceId": "d37f35bf-4dce-4291-9812-477382595e4b"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:30 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - c9f3ea63-7398-4cd5-9cf5-aeda662e1ce6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/items
+  response:
+    body:
+      string: '{"value": [{"id": "d5b1ed2d-b57a-474d-b4a5-7606c421db31", "type": "Notebook",
+        "displayName": "fabcli000002", "description": "Created by fab", "workspaceId":
+        "d37f35bf-4dce-4291-9812-477382595e4b", "folderId": "90959334-3fa8-4800-9ab7-124e5679e6a2"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '209'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:29 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 7e844fd0-7b73-47e9-b9c1-fa4a9a232b36
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": [{"id": "90959334-3fa8-4800-9ab7-124e5679e6a2", "displayName":
+        "fabcli000001", "workspaceId": "d37f35bf-4dce-4291-9812-477382595e4b"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:30 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 1f165cff-f940-4464-9c90-3b7083eaac39
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: DELETE
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/items/d5b1ed2d-b57a-474d-b4a5-7606c421db31
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 25 Sep 2025 09:14:31 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - f3ece86d-ddbd-4bed-af8d-f669d8e49e1c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "d37f35bf-4dce-4291-9812-477382595e4b",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "Created
+        by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '820'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:31 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 149de43f-4232-4a83-8e22-a927cb68f02e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders?recursive=True
+  response:
+    body:
+      string: '{"value": [{"id": "90959334-3fa8-4800-9ab7-124e5679e6a2", "displayName":
+        "fabcli000001", "workspaceId": "d37f35bf-4dce-4291-9812-477382595e4b"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 25 Sep 2025 09:14:32 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 42407cb6-36ca-43f5-9d17-a904df998ee1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.1.0
+    method: DELETE
+    uri: https://api.fabric.microsoft.com/v1/workspaces/d37f35bf-4dce-4291-9812-477382595e4b/folders/90959334-3fa8-4800-9ab7-124e5679e6a2
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 25 Sep 2025 09:14:32 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - ddfe63a0-29b9-455f-b9c2-2d916bb85a34
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_commands/test_mkdir.py
+++ b/tests/test_commands/test_mkdir.py
@@ -1616,6 +1616,37 @@ class TestMkdir:
     # endregion
 
     # region Folders
+    
+    def test_mkdir_item_in_folder_listing_success(
+        self, workspace, cli_executor, mock_print_done, mock_questionary_print, mock_fab_set_state_config, vcr_instance, cassette_name
+    ):
+        # Enable folder listing
+        mock_fab_set_state_config(constant.FAB_FOLDER_LISTING_ENABLED, "true")
+
+        
+        # Setup
+        folder_name = f"{generate_random_string(vcr_instance, cassette_name)}.Folder"
+        folder_full_path = cli_path_join(workspace.full_path, folder_name)
+        
+        # Create folder
+        cli_executor.exec_command(f"mkdir {folder_full_path}")
+        mock_print_done.assert_called_once()
+        mock_print_done.reset_mock()
+        
+        # Create notebook in folder
+        notebook_name = f"{generate_random_string(vcr_instance, cassette_name)}.Notebook"
+        notebook_full_path = cli_path_join(folder_full_path, notebook_name)
+        cli_executor.exec_command(f"mkdir {notebook_full_path}")
+        
+        # Verify notebook appears in folder listing
+        cli_executor.exec_command(f"ls {folder_full_path}")
+        printed_output = mock_questionary_print.call_args[0][0]
+        assert notebook_name in printed_output
+        
+        # Cleanup
+        rm(notebook_full_path)
+        rm(folder_full_path)
+
 
     def test_mkdir_folder_success(self, workspace, cli_executor, mock_print_done):
         # Setup


### PR DESCRIPTION
Issue: When FAB_FOLDER_LISTING_ENABLED is set to true, creating a new item under a folder and then running ls does not show the newly created item in the listing.
Root Cause: The folder cache is not being invalidated—only the item cache is refreshed.
Fix: We need to ensure the folder cache is also invalidated to reflect the latest changes in the listing.