### PR TITLE
fix: cp item to another WS

### DIFF
--- a/docs/commands/fs/cp.md
+++ b/docs/commands/fs/cp.md
@@ -13,7 +13,7 @@ The behavior of the `cp` command varies depending on the source (item or folder)
 **Usage:**
 
 ```
-fab cp <from_path> <to_path> [-r] [-f]
+fab cp <from_path> <to_path> [-r] [-f] [-ftp]
 ```
 
 **Parameters:**
@@ -22,6 +22,7 @@ fab cp <from_path> <to_path> [-r] [-f]
 - `<to_path>`: Destination path.
 - `-r, --recursive`: Copies all items in the source path, including subfolders and their contents (only applicable for workspaces and folders). Optional.
 - `-f, --force`: Force copy without confirmation. Optional.
+- `-ftp, --force-target-path`: Force target path. Prevents copying when an item with the same name exists in a different folder within the target workspace. Optional.
 
 
 ## Limitations

--- a/src/fabric_cli/commands/fs/cp/fab_fs_cp_item.py
+++ b/src/fabric_cli/commands/fs/cp/fab_fs_cp_item.py
@@ -14,10 +14,10 @@ from fabric_cli.core.fab_exceptions import FabricCLIError
 from fabric_cli.core.fab_types import ItemType
 from fabric_cli.core.hiearchy.fab_hiearchy import Folder, Item, Workspace
 from fabric_cli.errors import ErrorMessages
+from fabric_cli.utils import fab_item_util as item_utils
 from fabric_cli.utils import fab_mem_store as utils_mem_store
 from fabric_cli.utils import fab_ui as utils_ui
 from fabric_cli.utils import fab_util as util
-from fabric_cli.utils import fab_item_util as item_utils
 
 
 def copy_items(
@@ -137,19 +137,33 @@ def cp_single_item(
 
         if _confirm_copy(args.force, is_move_command):
             item_already_exists = False
-            # Check if the item already exists
-            if any(
-                target_item.name == to_context.name for target_item in ws_items_target
-            ):
+            existing_item_with_same_name = None
+            destination_path = args.to_path
+
+            existing_item_with_same_name = next(
+                (item for item in ws_items_target if item.name == to_context.name), None
+            )
+
+            if existing_item_with_same_name:
+                if existing_item_with_same_name.parent != to_context.parent:
+                    if hasattr(args, "force_target_path") and args.force_target_path:
+                        raise FabricCLIError(
+                            "An item with the same name exists in a different location within the workspace.",
+                            fab_constant.ERROR_INVALID_INPUT,
+                        )
+                    else:
+                        destination_path = existing_item_with_same_name.path
+
                 item_already_exists = True
-                fab_logger.log_warning("An item with the same name exists")
+                fab_logger.log_warning(
+                    f"An item with the same name exists in {destination_path}"
+                )
                 if args.force or utils_ui.prompt_confirm("Overwrite?"):
                     pass
                 else:
                     return False
-
             utils_ui.print_grey(
-                f"{'Moving' if delete_after_copy else 'Copying'} '{args.from_path}' → '{args.to_path}'..."
+                f"{'Moving' if delete_after_copy else 'Copying'} '{args.from_path}' → '{destination_path}'..."
             )
             # Copy including definition, cross ws
             _copy_item_with_definition(
@@ -167,8 +181,6 @@ def cp_single_item(
 
 
 # Utils
-
-
 def _confirm_copy(bypass_confirmation: bool, is_move_command: bool) -> bool:
     if not bool(bypass_confirmation):
         confirm_message = item_utils.get_confirm_copy_move_message(is_move_command)

--- a/src/fabric_cli/parsers/fab_fs_parser.py
+++ b/src/fabric_cli/parsers/fab_fs_parser.py
@@ -207,6 +207,13 @@ def register_cp_parser(subparsers: _SubParsersAction) -> None:
         action="store_true",
         help="Recursive. Optional, copies all items in the source path recursively, including subfolders and their contents. This option is only applicable for workspaces and folders.",
     )
+    cp_parser.add_argument(
+        "-ftp",
+        "--force-target-path",
+        required=False,
+        action="store_true",
+        help="Force target path. Optional, prevents copying when an item with the same name exists in a different folder within the target workspace.",
+    )
 
     cp_parser.usage = f"{utils_error_parser.get_usage_prog(cp_parser)}"
     cp_parser.set_defaults(func=fs.cp_command)
@@ -324,10 +331,10 @@ def register_get_parser(subparsers: _SubParsersAction) -> None:
     ]
 
     get_parser = subparsers.add_parser(
-        "get", 
+        "get",
         help=fab_constant.COMMAND_FS_GET_DESCRIPTION,
-        fab_examples=get_examples, 
-        fab_learnmore=get_learnmore
+        fab_examples=get_examples,
+        fab_learnmore=get_learnmore,
     )
     get_parser.add_argument("path", nargs="+", type=str, help="Directory path")
     get_parser.add_argument(
@@ -416,10 +423,10 @@ def register_set_parser(subparsers: _SubParsersAction) -> None:
     ]
 
     set_parser = subparsers.add_parser(
-        "set", 
+        "set",
         help=fab_constant.COMMAND_FS_SET_DESCRIPTION,
-        fab_examples=set_examples, 
-        fab_learnmore=set_learnmore
+        fab_examples=set_examples,
+        fab_learnmore=set_learnmore,
     )
     set_parser.add_argument("path", nargs="+", type=str, help="Directory path")
     set_parser.add_argument(
@@ -443,7 +450,9 @@ def register_set_parser(subparsers: _SubParsersAction) -> None:
 
 # Command for 'clear'
 def register_clear_parser(subparsers: _SubParsersAction) -> None:
-    clear_parser = subparsers.add_parser("clear", aliases=["cls"], help=fab_constant.COMMAND_FS_CLEAR_DESCRIPTION)
+    clear_parser = subparsers.add_parser(
+        "clear", aliases=["cls"], help=fab_constant.COMMAND_FS_CLEAR_DESCRIPTION
+    )
     clear_parser.usage = f"{utils_error_parser.get_usage_prog(clear_parser)}"
     clear_parser.set_defaults(func=do_clear)
 


### PR DESCRIPTION
When attempting to copy (cp) an item from one workspace (WS) to another, if an item with the same name already exists in a different folder within the target workspace (not the destination folder), the user receives no indication that overwriting the existing file will impact a folder other than the one they selected as the target.

In this PR I fixed the destination path loging to reflect where the item will be copied, and added a new `--force-target-path` (`-ftp`) option to the `fab cp` command, enhancing how file and folder copy conflicts are handled within a workspace.
