### PR TITLE
chore: Add approved reply to triaged issue

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -88,9 +88,7 @@ configuration:
               label: needs triage
           - addReply:
               reply: >
-                This issue has been **approved** after triage review.
-                
-                The Fabric CLI team will evaluate whether to mark this as 'help wanted' for community contribution or assign it to a team member to address it directly.
+                **Triage has been completed** for this issue.
 
       - description: Accept as help wanted
         if:


### PR DESCRIPTION
# 📥 Pull Request

This PR updates the triage workflow to automatically add a reply to an issue when it is approved.

## ✨ Description of new changes

- 🤖 Added an automated reply to the `resourceManagement.yml` policy file.
- 💬 The new reply informs the user that the issue has been approved and will be evaluated by the Fabric CLI team.