### PR TITLE
fix: fix changie workflow

### DIFF
--- a/.github/workflows/changelog-existence.yml
+++ b/.github/workflows/changelog-existence.yml
@@ -83,7 +83,7 @@ jobs:
         if: steps.changelog_check.outputs.exists == 'false'
         run: |
           echo "🛑 Changelog entry required to merge."
-          echo "   Please run 'changie new' to add a new changelog entry."
+          echo "🛑 Please run 'changie new' to add a new changelog entry."
           exit 1
 
   changelog-skip:


### PR DESCRIPTION
# 📥 Pull Request

## ✨ Description of new changes

This PR resolves the `HttpError: Resource not accessible by integration` error in the `changelog-existence` workflow by removing the pull request commenting logic.

All feedback, including changelog previews and error messages, is now displayed directly in the GitHub Actions step summary. This simplifies the workflow, enhances security by reducing permissions, and provides a more reliable feedback mechanism for all pull requests.