### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/.changes/unreleased/added-20251111-144602.yaml
+++ b/.changes/unreleased/added-20251111-144602.yaml
@@ -1,3 +1,0 @@
-kind: added
-body: Add support of mv, cp, export and import for SQLDatabase item type
-time: 2025-11-11T14:46:02.635689113Z

--- a/.changes/unreleased/added-20251111-210116.yaml
+++ b/.changes/unreleased/added-20251111-210116.yaml
@@ -1,3 +1,0 @@
-kind: added
-body: Add new 'job run-rm' command for remove a scheduled job
-time: 2025-11-11T21:01:16.593478128Z

--- a/.changes/unreleased/added-20251113-131349.yaml
+++ b/.changes/unreleased/added-20251113-131349.yaml
@@ -1,3 +1,0 @@
-kind: added
-body: Enhance `set` command for items to support any settable property path within the item's definition and metadata structure
-time: 2025-11-13T13:13:49.062462673Z

--- a/.changes/unreleased/added-20251120-143304.yaml
+++ b/.changes/unreleased/added-20251120-143304.yaml
@@ -1,3 +1,0 @@
-kind: added
-body: Add support in `ls` commmand using `-q` flag for filtering based on JMESPath expressions
-time: 2025-11-20T14:33:04.564732218Z

--- a/.changes/unreleased/docs-20251130-120623.yaml
+++ b/.changes/unreleased/docs-20251130-120623.yaml
@@ -1,3 +1,0 @@
-kind: docs
-body: Documentation updates
-time: 2025-11-30T12:06:23.730098188Z

--- a/.changes/unreleased/fixed-20251103-083447.yaml
+++ b/.changes/unreleased/fixed-20251103-083447.yaml
@@ -1,3 +1,0 @@
-kind: fixed
-body: Fix `--output_format` argument for command `fab auth status`
-time: 2025-11-03T08:34:47.3979808+01:00

--- a/.changes/unreleased/fixed-20251111-053940.yaml
+++ b/.changes/unreleased/fixed-20251111-053940.yaml
@@ -1,3 +1,0 @@
-kind: fixed
-body: Fix context persistence in virtual environment
-time: 2025-11-11T05:39:40.62257109Z

--- a/.changes/unreleased/fixed-20251111-134254.yaml
+++ b/.changes/unreleased/fixed-20251111-134254.yaml
@@ -1,3 +1,0 @@
-kind: fixed
-body: Fix create connection with onPremGateway and encryptedCredentials
-time: 2025-11-11T13:42:54.695045434Z

--- a/.changes/unreleased/optimization-20251112-081104.yaml
+++ b/.changes/unreleased/optimization-20251112-081104.yaml
@@ -1,3 +1,0 @@
-kind: optimization
-body: Add support for print in key-value list style
-time: 2025-11-12T08:11:04.00625845Z

--- a/.changes/unreleased/optimization-20251119-095159.yaml
+++ b/.changes/unreleased/optimization-20251119-095159.yaml
@@ -1,3 +1,0 @@
-kind: optimization
-body: Optimize LRO polling by calling GetOperationResult API only when a Location header is present
-time: 2025-11-19T09:51:59.752824783Z

--- a/.changes/unreleased/optimization-20251127-181226.yaml
+++ b/.changes/unreleased/optimization-20251127-181226.yaml
@@ -1,3 +1,0 @@
-kind: optimization
-body: Enforce CLI parameter values must be wrapped in single (') or double (") quotes in interactive mode
-time: 2025-11-27T18:12:26.528482123Z

--- a/.changes/v1.3.0.md
+++ b/.changes/v1.3.0.md
@@ -1,0 +1,25 @@
+## [v1.3.0](https://pypi.org/project/ms-fabric-cli/v1.3.0) - December 15, 2025
+
+### ✨ New Functionality
+
+* Add support of mv, cp, export and import for SQLDatabase item type
+* Add new 'job run-rm' command for remove a scheduled job
+* Enhance `set` command for items to support any settable property path within the item's definition and metadata structure
+* Add support in `ls` commmand using `-q` flag for filtering based on JMESPath expressions
+
+### 🔧 Bug Fix
+
+* Fix `--output_format` argument for command `fab auth status`
+* Fix context persistence in virtual environment
+* Fix create connection with onPremGateway and encryptedCredentials
+
+### ⚡ Additional Optimizations
+
+* Add support for print in key-value list style
+* Optimize LRO polling by calling GetOperationResult API only when a Location header is present
+* Enforce CLI parameter values must be wrapped in single (') or double (") quotes in interactive mode
+
+### 📝 Documentation Update
+
+* Documentation updates
+

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,32 @@ hide:
 # Release Notes
 
 
+## [v1.3.0](https://pypi.org/project/ms-fabric-cli/v1.3.0) - December 15, 2025
+
+### ✨ New Functionality
+
+* Add support of mv, cp, export and import for SQLDatabase item type
+* Add new 'job run-rm' command for remove a scheduled job
+* Enhance `set` command for items to support any settable property path within the item's definition and metadata structure
+* Add support in `ls` commmand using `-q` flag for filtering based on JMESPath expressions
+
+### 🔧 Bug Fix
+
+* Fix `--output_format` argument for command `fab auth status`
+* Fix context persistence in virtual environment
+* Fix create connection with onPremGateway and encryptedCredentials
+
+### ⚡ Additional Optimizations
+
+* Add support for print in key-value list style
+* Optimize LRO polling by calling GetOperationResult API only when a Location header is present
+* Enforce CLI parameter values must be wrapped in single (') or double (") quotes in interactive mode
+
+### 📝 Documentation Update
+
+* Documentation updates
+
+
 ## [v1.2.0](https://pypi.org/project/ms-fabric-cli/v1.2.0) - October 21, 2025
 
 ### 🆕 New Items Support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name="ms-fabric-cli"
 authors = [
     { name = "Microsoft Corporation" },
 ]
-version="1.2.0"
+version="1.3.0"
 description="Command-line tool for Microsoft Fabric"
 readme="README.md"
 requires-python=">=3.10,<3.13"

--- a/src/fabric_cli/__init__.py
+++ b/src/fabric_cli/__init__.py
@@ -2,4 +2,4 @@
 # Licensed under the MIT License.
 
 # Don't change this
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/src/fabric_cli/core/fab_constant.py
+++ b/src/fabric_cli/core/fab_constant.py
@@ -27,7 +27,7 @@ API_USER_AGENT_TEST = "ms-fabric-cli-test"
 WEB_URI = "https://app.powerbi.com/groups"
 
 # Versioning
-FAB_VERSION = "1.2.0"  # change pyproject.toml version too, this must be aligned
+FAB_VERSION = "1.3.0"  # change pyproject.toml version too, this must be aligned
 
 # Scopes
 SCOPE_FABRIC_DEFAULT = ["https://analysis.windows.net/powerbi/api/.default"]


### PR DESCRIPTION
## [v1.3.0](https://pypi.org/project/ms-fabric-cli/v1.3.0) - December 15, 2025

### ✨ New Functionality

* Add support of mv, cp, export and import for SQLDatabase item type
* Add new 'job run-rm' command for remove a scheduled job
* Enhance `set` command for items to support any settable property path within the item's definition and metadata structure
* Add support in `ls` commmand using `-q` flag for filtering based on JMESPath expressions

### 🔧 Bug Fix

* Fix `--output_format` argument for command `fab auth status`
* Fix context persistence in virtual environment
* Fix create connection with onPremGateway and encryptedCredentials

### ⚡ Additional Optimizations

* Add support for print in key-value list style
* Optimize LRO polling by calling GetOperationResult API only when a Location header is present
* Enforce CLI parameter values must be wrapped in single (') or double (") quotes in interactive mode

### 📝 Documentation Update

* Documentation updates
