### PR TITLE
ci: add contributor attribution to changelog entries

### DIFF
--- a/.changes/unreleased/added-20251120-025450.yaml
+++ b/.changes/unreleased/added-20251120-025450.yaml
@@ -1,7 +1,6 @@
 kind: added
-body: Add --format option to export command to pick .ipynb or .py when exporting notebooks 
+body: Add --format option to export command to pick .ipynb or .py when exporting notebooks
 time: 2025-11-20T02:54:50.543931335Z
 custom:
-    Author: jkafrouni
-    AuthorLink: https://github.com/jkafrouni
-    
+  Author: jkafrouni
+  AuthorLink: https://github.com/jkafrouni

--- a/.changes/unreleased/added-20251209-141353.yaml
+++ b/.changes/unreleased/added-20251209-141353.yaml
@@ -2,6 +2,5 @@ kind: added
 body: Include API response data in the output
 time: 2025-12-09T14:13:53.030608891Z
 custom:
-    Author: aviatco
-    AuthorLink: https://github.com/aviatco
-    
+  Author: aviatco
+  AuthorLink: https://github.com/aviatco

--- a/.changes/unreleased/added-20251211-183425.yaml
+++ b/.changes/unreleased/added-20251211-183425.yaml
@@ -2,5 +2,5 @@ kind: added
 body: Display a notification to users on login when a new fab cli version is available
 time: 2025-12-11T18:34:25.601088227+01:00
 custom:
-    Author: Guust-Franssens
-    AuthorLink: https://github.com/Guust-Franssens
+  Author: Guust-Franssens
+  AuthorLink: https://github.com/Guust-Franssens

--- a/.changes/unreleased/fixed-20251203-155412.yaml
+++ b/.changes/unreleased/fixed-20251203-155412.yaml
@@ -2,6 +2,5 @@ kind: fixed
 body: Avoid reauthentication when switching from command_line to interactive mode
 time: 2025-12-03T15:54:12.961104889Z
 custom:
-    Author: aviatco
-    AuthorLink: https://github.com/aviatco
-    
+  Author: aviatco
+  AuthorLink: https://github.com/aviatco

--- a/.changes/unreleased/fixed-20251228-073108.yaml
+++ b/.changes/unreleased/fixed-20251228-073108.yaml
@@ -2,6 +2,5 @@ kind: fixed
 body: Fixed set shortcut so it correctly handles target query
 time: 2025-12-28T07:31:08.76557913Z
 custom:
-    Author: may-hartov
-    AuthorLink: https://github.com/may-hartov
-    
+  Author: may-hartov
+  AuthorLink: https://github.com/may-hartov

--- a/.changes/unreleased/fixed-20260102-172853.yaml
+++ b/.changes/unreleased/fixed-20260102-172853.yaml
@@ -2,5 +2,5 @@ kind: fixed
 body: Fix a typo in connection roles
 time: 2026-01-02T17:28:53.418628486+01:00
 custom:
-    Author: Guust-Franssens
-    AuthorLink: https://github.com/Guust-Franssens
+  Author: Guust-Franssens
+  AuthorLink: https://github.com/Guust-Franssens

--- a/.changes/unreleased/optimization-20251223-155633.yaml
+++ b/.changes/unreleased/optimization-20251223-155633.yaml
@@ -2,6 +2,5 @@ kind: optimization
 body: Improve the error message to clearly indicate when the MPE creator does not have sufficient Azure permissions on the resource.
 time: 2025-12-23T15:56:33.427481409Z
 custom:
-    Author: aviatco
-    AuthorLink: https://github.com/aviatco
-    
+  Author: aviatco
+  AuthorLink: https://github.com/aviatco

--- a/.changes/unreleased/optimization-20251225-091556.yaml
+++ b/.changes/unreleased/optimization-20251225-091556.yaml
@@ -2,6 +2,5 @@ kind: optimization
 body: Reduced unnecessary Fabric administrator warnings for ACL commands
 time: 2025-12-25T09:15:56.219714671Z
 custom:
-    Author: ayeshurun
-    AuthorLink: https://github.com/ayeshurun
-    
+  Author: ayeshurun
+  AuthorLink: https://github.com/ayeshurun

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,25 +6,25 @@ headerPath: header.tpl.md
 versionExt: md
 changelogPath: docs/release-notes.md
 versionFormat: '## [{{.Version}}](https://pypi.org/project/ms-fabric-cli/{{.Version}}) - {{.Time.Format "January 02, 2006"}}'
-kindFormat: '### {{.Kind}}'
-changeFormat: '* {{.Body}} by [{{.Custom.Author}}]({{.Custom.AuthorLink}})'
+kindFormat: "### {{.Kind}}"
+changeFormat: "* {{.Body}} by [{{.Custom.Author}}]({{.Custom.AuthorLink}})"
 kinds:
-  - label: '⚠️ Breaking Change'
+  - label: "⚠️ Breaking Change"
     key: breaking
     auto: minor
-  - label: '🆕 New Items Support'
+  - label: "🆕 New Items Support"
     key: new-items
     auto: minor
-  - label: '✨ New Functionality'
+  - label: "✨ New Functionality"
     key: added
     auto: minor
-  - label: '🔧 Bug Fix'
+  - label: "🔧 Bug Fix"
     key: fixed
     auto: patch
-  - label: '⚡ Additional Optimizations'
+  - label: "⚡ Additional Optimizations"
     key: optimization
     auto: patch
-  - label: '📝 Documentation Update'
+  - label: "📝 Documentation Update"
     key: docs
     auto: patch
 newlines:
@@ -52,4 +52,3 @@ replacements:
   - path: src/fabric_cli/core/fab_constant.py
     find: 'FAB_VERSION = ".*"'
     replace: 'FAB_VERSION = "{{.VersionNoPrefix}}"'
-    

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version to release (e.g., v1.2.0)'
+        description: "The version to release (e.g., v1.2.0)"
         required: true
       commit_sha:
-        description: 'Optional: Commit SHA to create the tag on. If not provided, the tag will be created on the latest commit of the current branch (HEAD)'
+        description: "Optional: Commit SHA to create the tag on. If not provided, the tag will be created on the latest commit of the current branch (HEAD)"
         required: false
-        default: ''
+        default: ""
 
 jobs:
   create-release:
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Required to access full commit history for validation
+          fetch-depth: 0 # Required to access full commit history for validation
 
       - name: Display workflow information
         run: |
@@ -29,14 +29,14 @@ jobs:
           else
             TARGET_INFO="- **Target Commit:** Latest commit on current branch (HEAD)"
           fi
-          
+
           cat >> $GITHUB_STEP_SUMMARY << EOF
           # 🚀 Create Release Workflow
-          
+
           ## ℹ️ Workflow Information
           - **Version:** ${{ github.event.inputs.version }}
           $TARGET_INFO
-          
+
           EOF
 
       - name: Validate commit SHA (if provided)
@@ -46,14 +46,14 @@ jobs:
           if ! git rev-parse --verify "$COMMIT_SHA^{commit}" >/dev/null 2>&1; then
             cat >> $GITHUB_STEP_SUMMARY << EOF
           ## ❌ Error: Invalid Commit SHA
-          
+
           The provided commit SHA \`$COMMIT_SHA\` is not valid or does not exist in this repository.
-          
+
           ### 📝 Troubleshooting
           - Verify the commit SHA exists in the repository
           - Ensure you are using the full commit SHA (or at least 7 characters)
           - Check that the commit is in the current branch history
-          
+
           EOF
             echo "Error: Invalid commit SHA: $COMMIT_SHA"
             exit 1
@@ -65,22 +65,22 @@ jobs:
         run: |
           VERSION="${{ github.event.inputs.version }}"
           COMMIT_SHA="${{ github.event.inputs.commit_sha }}"
-          
+
           # Use provided commit SHA or default to HEAD
           if [ -n "$COMMIT_SHA" ]; then
             TARGET_COMMIT="$COMMIT_SHA"
           else
             TARGET_COMMIT="HEAD"
           fi
-          
+
           echo "tag_name=$VERSION" >> $GITHUB_OUTPUT
           echo "changelog_file_path=.changes/${VERSION}.md" >> $GITHUB_OUTPUT
           echo "target_commit=$TARGET_COMMIT" >> $GITHUB_OUTPUT
-          
+
           # Get the actual commit SHA for display
           ACTUAL_SHA=$(git rev-parse "$TARGET_COMMIT")
           echo "actual_sha=$ACTUAL_SHA" >> $GITHUB_OUTPUT
-          
+
           echo "✅ Release variables set:"
           echo "  - Tag name: $VERSION"
           echo "  - Target commit: $ACTUAL_SHA"
@@ -92,23 +92,23 @@ jobs:
           if [ ! -f "$CHANGELOG_FILE" ]; then
             cat >> $GITHUB_STEP_SUMMARY << EOF
           ## ❌ Error: Release Notes File Not Found
-          
+
           The release notes file was not found at the expected location:
-          
+
           \`\`\`
           $CHANGELOG_FILE
           \`\`\`
-          
+
           ### 📝 What to do:
           1. Ensure you have created the changelog file for version \`${{ steps.set_vars.outputs.tag_name }}\`
           2. The file should be located at: \`.changes/${{ steps.set_vars.outputs.tag_name }}.md\`
           3. You can use \`changie batch <version>\` to generate the changelog file
-          
+
           ### 📂 Available changelog files:
           \`\`\`
           $(ls -1 .changes/*.md 2>/dev/null || echo "No changelog files found")
           \`\`\`
-          
+
           EOF
             echo "Error: Release notes file not found at $CHANGELOG_FILE"
             exit 1
@@ -121,14 +121,14 @@ jobs:
         run: |
           cat >> $GITHUB_STEP_SUMMARY << EOF
           ## 🏗️ Creating Release
-          
+
           Creating release with the following details:
           - **Tag:** \`${{ steps.set_vars.outputs.tag_name }}\`
           - **Target Commit:** \`${{ steps.set_vars.outputs.actual_sha }}\`
           - **Notes File:** \`${{ steps.set_vars.outputs.changelog_file_path }}\`
-          
+
           EOF
-          
+
           # Create the release with the target commit
           if gh release create ${{ steps.set_vars.outputs.tag_name }} \
             --title "${{ steps.set_vars.outputs.tag_name }}" \
@@ -137,34 +137,33 @@ jobs:
             
             cat >> $GITHUB_STEP_SUMMARY << EOF
           ## ✅ Release Created Successfully!
-          
+
           🎉 **Release \`${{ steps.set_vars.outputs.tag_name }}\` has been created!**
-          
+
           ### 📋 Release Details:
           - **Tag:** \`${{ steps.set_vars.outputs.tag_name }}\`
           - **Commit:** \`${{ steps.set_vars.outputs.actual_sha }}\`
           - **Release URL:** [View Release](https://github.com/${{ github.repository }}/releases/tag/${{ steps.set_vars.outputs.tag_name }})
-          
+
           EOF
           else
             cat >> $GITHUB_STEP_SUMMARY << EOF
           ## ❌ Error: Failed to Create Release
-          
+
           The GitHub CLI failed to create the release. This could be due to:
-          
+
           ### 🔍 Common Issues:
           - A release with tag \`${{ steps.set_vars.outputs.tag_name }}\` already exists
           - Insufficient permissions to create releases
           - Network connectivity issues
           - Invalid release notes format
-          
+
           ### 📝 Next Steps:
           1. Check if the tag already exists: \`git tag -l '${{ steps.set_vars.outputs.tag_name }}'\`
           2. Verify you have the necessary permissions to create releases
           3. Review the workflow run logs for detailed error messages
-          
+
           EOF
             echo "Error: Failed to create release"
             exit 1
           fi
-          


### PR DESCRIPTION
# 📥 Pull Request

<!--
Pull request title must follows the [Conventional Commits](https://www.conventionalcommits.org/) format (`type(scope): subject`).

**type**: Must be one of the following:

- `feat`: A new feature
- `fix`: A bug fix
- `docs`: Documentation only changes
- `style`: Changes that do not affect the meaning of the code (e.g., formatting)
- `refactor`: A code change that neither fixes a bug nor adds a feature
- `perf`: A code change that improves performance
- `test`: Adding missing tests or correcting existing tests
- `chore`: Changes to the build process or auxiliary tools
- `build`: Changes that affect the build system or external dependencies
- `ci`: Changes to CI configuration files and scripts
- `revert`: Reverts a previous commit
-->

## ✨ Description of new changes

This PR enhances the changelog generation system to automatically attribute changes to their contributors.

Going forward, when contributors create changelog entries using changie new, they'll be prompted to provide their GitHub username, which will be automatically linked in the generated release notes. This improves transparency and gives proper credit to all contributors.