### PR TITLE
refactor: Add new GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,4 +1,4 @@
-name: "🐛 Bug report"
+name: "🐛 Bug Report"
 description: Create a report to help us improve fabric-cli
 title: "[BUG] "
 labels: []

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,4 +1,4 @@
-name: "🚀 Feature request"
+name: "🚀 Feature Request"
 description: Suggest an idea or enhancement for fabric-cli
 title: "[FEATURE] "
 labels: ["enhancement"]

--- a/.github/ISSUE_TEMPLATE/3-question.yml
+++ b/.github/ISSUE_TEMPLATE/3-question.yml
@@ -1,4 +1,4 @@
-name: "❓ General question"
+name: "❓ General Question"
 description: Ask a question about using fabric-cli
 title: "[QUESTION] "
 labels: ["question"]

--- a/.github/ISSUE_TEMPLATE/4-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/4-documentation.yml
@@ -1,0 +1,81 @@
+name: "📝 Documentation Feedback"
+description: Provide documentation feedback
+title: "[DOCUMENTATION] "
+labels: ["documentation"]
+body:
+    - type: markdown
+      attributes:
+          value: Thanks for taking the time to provide documentation feedback! Please include as much detail as possible to help us improve our documentation.
+
+    - type: input
+      id: documentation-location
+      attributes:
+          label: URL to documentation
+          description: Provide a URL to the documentation location.
+          placeholder: "https://microsoft.github.io/fabric-cli/..."
+      validations:
+          required: true
+
+    - type: dropdown
+      id: feedback-type
+      attributes:
+          label: Type of feedback
+          description: What kind of documentation issue is this?
+          options:
+              - Unclear or confusing content
+              - Missing information
+              - Incorrect or outdated information
+              - Typo or grammatical error
+              - Code example issue
+              - Broken link
+              - Suggestion for improvement
+              - Other
+      validations:
+          required: true
+
+    - type: textarea
+      id: current-content
+      attributes:
+          label: Current content
+          description: Copy the relevant section of documentation that needs improvement (if applicable).
+          placeholder: "Paste the current text or describe what exists..."
+      validations:
+          required: false
+
+    - type: textarea
+      id: feedback
+      attributes:
+          label: Feedback
+          description: What is the issue or what improvement would you suggest?
+          placeholder: "Describe what's wrong or what could be better..."
+      validations:
+          required: true
+
+    - type: textarea
+      id: suggested-change
+      attributes:
+          label: Suggested change
+          description: If you have a specific suggestion, please provide it here.
+          placeholder: "Provide your suggested text, code, or improvement..."
+      validations:
+          required: false
+
+    - type: dropdown
+      id: user-experience
+      attributes:
+          label: Experience with fabric-cli
+          description: This helps us understand our audience better.
+          options:
+              - New to fabric-cli
+              - Some experience with fabric-cli
+              - Experienced user
+      validations:
+          required: false
+
+    - type: textarea
+      id: additional-context
+      attributes:
+          label: Additional context
+          description: Add any other context, screenshots, or related links here.
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/5-copilot.yml
+++ b/.github/ISSUE_TEMPLATE/5-copilot.yml
@@ -1,0 +1,111 @@
+name: "🤖 GitHub Copilot Assignment"
+description: Issue template for tasks assigned to GitHub Copilot Agent
+title: "[COPILOT] "
+labels: ["copilot"]
+body:
+    - type: markdown
+      attributes:
+          value: Used internally to raise issues specifically for GitHub Copilot agent assistance. Provide as much context as possible to help the agent work efficiently.
+
+    - type: dropdown
+      id: task-type
+      attributes:
+          label: Task Type
+          description: What kind of work is this?
+          options:
+              - Bug fix
+              - New feature
+              - Refactoring
+              - Documentation
+              - Tests
+              - Other
+      validations:
+          required: true
+
+    - type: textarea
+      id: task-description
+      attributes:
+          label: Task Description
+          description: Describe what needs to be done and any relevant context.
+          placeholder: |
+              What needs to be done:
+              Context/Background:
+              Error message (if applicable):
+      validations:
+          required: true
+
+    - type: textarea
+      id: affected-components
+      attributes:
+          label: Affected Files/Components
+          description: List specific files, modules, or components involved.
+          placeholder: |
+              src/fabric_cli/commands/fs/fab_fs_ls.py
+              src/fabric_cli/utils/fab_ui.py
+              tests/test_commands/test_fs_ls.py
+      validations:
+          required: false
+
+    - type: textarea
+      id: reproduction-steps
+      attributes:
+          label: Reproduction Steps
+          description: Steps to reproduce the issue (for bugs).
+          placeholder: |
+              1. Run `fab auth login`
+              2. Run `fab ls /WorkspaceName.Workspace`
+              3. Observe error...
+      validations:
+          required: false
+
+    - type: textarea
+      id: solution-description
+      attributes:
+          label: Proposed Solution
+          description: Describe the ideal solution with specific technical details.
+          placeholder: |
+              Approach:
+              Key changes needed:
+              Considerations:
+      validations:
+          required: false
+
+    - type: textarea
+      id: success-criteria
+      attributes:
+          label: Success Criteria
+          description: Define completion requirements. Remove items that don't apply.
+          placeholder: |
+              - All existing tests pass (`python3 -m pytest tests/test_core tests/test_utils`)
+              - Integration tests pass (`python3 -m pytest tests/test_commands --playback`)
+              - Code formatting passes (`black src/ tests/`)
+              - Type checking passes (`mypy src/ tests/ --ignore-missing-imports`)
+              - New tests added for changes
+              - Error handling uses FabricCLIError with proper error codes
+              - Type hints on all new functions
+              - Documentation updated (if applicable)
+      validations:
+          required: false
+
+    - type: textarea
+      id: scope-boundaries
+      attributes:
+          label: Scope & Boundaries
+          description: What should NOT be changed or is out of scope?
+          placeholder: |
+              Do NOT modify:
+              Out of scope:
+      validations:
+          required: false
+
+    - type: textarea
+      id: related-context
+      attributes:
+          label: Related Issues/PRs/Docs
+          description: Links to related issues, PRs, or documentation.
+          placeholder: |
+              - Related to #123
+              - See docs/commands/index.md
+              - Fabric CLI docs: https://aka.ms/fabric-cli
+      validations:
+          required: false


### PR DESCRIPTION
This pull request updates and expands the GitHub issue templates for the project, improving clarity and introducing new templates for documentation feedback and Copilot agent tasks. The changes standardize naming conventions and add more structured options for users and contributors to provide feedback or request help.

**New issue templates:**

* Added a detailed documentation feedback template to collect structured input on documentation issues and improvements. (.github/ISSUE_TEMPLATE/4-documentation.yml)
* Introduced a Copilot assignment template for internal use, enabling structured task assignment to the GitHub Copilot agent. (.github/ISSUE_TEMPLATE/5-copilot.yml)

**Improvements to existing templates:**

* Standardized the naming of issue templates by capitalizing key words for consistency and clarity. (.github/ISSUE_TEMPLATE/1-bug.yml, .github/ISSUE_TEMPLATE/2-feature.yml, .github/ISSUE_TEMPLATE/3-question.yml) [[1]](diffhunk://#diff-6776d62e4a2433668f6f50806c424a3f35f7c39b885e14ce2dc35ca8510b861aL1-R1) [[2]](diffhunk://#diff-1ec81c5c8c2cd65f57c32fb1f61ed32d7c1afb286ef327bed07d3b5acd0d4a8bL1-R1) [[3]](diffhunk://#diff-998c4f1b9f1d92814c3d3a0cd6c584e45c2c700b41d0ab0ed0f37409e2415e04L1-R1)