### PR TITLE
feat(auth): add multi-account session management

### DIFF
--- a/.changes/unreleased/added-20260407-201800.yaml
+++ b/.changes/unreleased/added-20260407-201800.yaml
@@ -1,0 +1,6 @@
+kind: added
+body: Add stored user session listing and switching for interactive authentication with `fab auth list` and `fab auth switch`
+time: 2026-04-07T20:18:00Z
+custom:
+    Author: Mathf18
+    AuthorLink: https://github.com/Mathf18

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ fab --version
 ```bash
 fab auth login
 # Select: "Interactive with a web browser"
+
+# List stored sessions
+fab auth list
+
+# Switch to another stored session
+fab auth switch
 ```
 
 ### Service Principal

--- a/docs/commands/auth/index.md
+++ b/docs/commands/auth/index.md
@@ -40,7 +40,7 @@ fab auth login [-u <client_id>] [-p <client_secret>] [--federated-token <token>]
 
 ### logout
 
-End the current authentication session.
+End the current authentication session. When multiple user sessions are stored you can target a specific session by account name and/or tenant.
 
 **Usage:**
 
@@ -48,11 +48,19 @@ End the current authentication session.
 fab auth logout [-u <account_name>] [-t <tenant_id>] [--all]
 ```
 
+**Parameters:**
+
+- `-u, --username`: Account name of the session to log out. Case-insensitive. Optional.
+- `-t, --tenant`: Tenant ID to disambiguate when the same account exists in multiple tenants. Optional.
+- `--all`: Clear all stored authentication sessions. Optional.
+
+When neither `-u` nor `--all` is provided, the CLI removes the current active session. If other sessions remain, the next most recently used session becomes active.
+
 ---
 
 ### list
 
-List stored user authentication sessions.
+List stored user authentication sessions. Each row shows whether the session is active, the account name, tenant, token validity, and the last used timestamp.
 
 **Usage:**
 
@@ -76,13 +84,24 @@ fab auth status
 
 ### switch
 
-Switch the active stored user authentication session.
+Switch the active stored user authentication session. You can specify the target account directly to avoid interactive selection.
 
 **Usage:**
 
 ```
 fab auth switch [-u <account_name>] [-t <tenant_id>]
 ```
+
+**Parameters:**
+
+- `-u, --username`: Account name to switch to. Case-insensitive. Optional.
+- `-t, --tenant`: Tenant ID to disambiguate when the same account exists in multiple tenants. Optional.
+
+**Behavior:**
+
+- With `-u` (and optionally `-t`): switches directly to the matching session.
+- With two stored sessions and no flags: automatically toggles to the other session.
+- With three or more sessions and no flags: presents an interactive prompt.
 
 ---
 

--- a/docs/commands/auth/index.md
+++ b/docs/commands/auth/index.md
@@ -12,7 +12,9 @@ Not resource-specific; applies to CLI authentication context.
 |----------------|---------------------------|-----------------------------------------------------------------------|
 | `auth login`   | Log in to Fabric CLI      | `auth login [parameters]`                                                |
 | `auth logout`  | Log out of current session| `auth logout`                                                         |
+| `auth list`    | List stored user sessions | `auth list`                                                           |
 | `auth status`  | Show authentication status| `auth status`                                                         |
+| `auth switch`  | Switch stored user session| `auth switch [parameters]`                                            |
 
 ---
 
@@ -43,7 +45,19 @@ End the current authentication session.
 **Usage:**
 
 ```
-fab auth logout
+fab auth logout [-u <account_name>] [-t <tenant_id>] [--all]
+```
+
+---
+
+### list
+
+List stored user authentication sessions.
+
+**Usage:**
+
+```
+fab auth list
 ```
 
 ---
@@ -56,6 +70,18 @@ Display current authentication state.
 
 ```
 fab auth status
+```
+
+---
+
+### switch
+
+Switch the active stored user authentication session.
+
+**Usage:**
+
+```
+fab auth switch [-u <account_name>] [-t <tenant_id>]
 ```
 
 ---

--- a/docs/examples/auth_examples.md
+++ b/docs/examples/auth_examples.md
@@ -114,6 +114,33 @@ Log out of the current Fabric CLI session and clear authentication tokens
 fab auth logout
 ```
 
+Log out of all stored authentication sessions
+
+```
+fab auth logout --all
+```
+
+
+## Stored Sessions
+
+### List stored user authentication sessions
+
+```
+fab auth list
+```
+
+### Switch to another stored user session
+
+```
+fab auth switch
+```
+
+### Switch directly to a specific stored account and tenant
+
+```
+fab auth switch -u <account_name> -t <tenant_id>
+```
+
 
 ## Authentication Status
 

--- a/docs/examples/auth_examples.md
+++ b/docs/examples/auth_examples.md
@@ -131,14 +131,38 @@ fab auth list
 
 ### Switch to another stored user session
 
+When two sessions are stored, `switch` automatically toggles to the other account:
+
 ```
 fab auth switch
+```
+
+With three or more sessions and no flags, an interactive prompt is shown.
+
+### Switch directly to a specific stored account
+
+Account name matching is case-insensitive:
+
+```
+fab auth switch -u alice@example.com
 ```
 
 ### Switch directly to a specific stored account and tenant
 
 ```
 fab auth switch -u <account_name> -t <tenant_id>
+```
+
+### Log out a specific stored session
+
+```
+fab auth logout -u alice@example.com
+```
+
+### Log out all stored sessions
+
+```
+fab auth logout --all
 ```
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,12 @@ For local development, sign in with your Microsoft account:
 
 ```bash
 fab auth login
+
+# Review stored user sessions
+fab auth list
+
+# Switch to another stored user session
+fab auth switch
 ```
 
 Select *Interactive with a web browser*. This opens your browser to complete authentication.
@@ -181,6 +187,5 @@ Add Fabric CLI to GitHub Actions, Azure Pipelines, and other DevOps tools. The s
 
 - Contact your Microsoft account manager
 - Open a ticket with the [Fabric Support Team](https://support.fabric.microsoft.com/)
-
 
 

--- a/src/fabric_cli/commands/auth/fab_auth.py
+++ b/src/fabric_cli/commands/auth/fab_auth.py
@@ -81,7 +81,10 @@ def init(args: Namespace) -> Any:
         try:
             if selected_auth == "Interactive with a web browser":
                 FabAuth().prepare_user_login(args.tenant)
-                FabAuth().get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
+                FabAuth().get_access_token(
+                    scope=fab_constant.SCOPE_FABRIC_DEFAULT,
+                    force_interactive=True,
+                )
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
                 Context().context = FabAuth().get_tenant()

--- a/src/fabric_cli/commands/auth/fab_auth.py
+++ b/src/fabric_cli/commands/auth/fab_auth.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 from argparse import Namespace
+import os
 from typing import Any, Optional
 
 from fabric_cli.core import fab_constant, fab_logger
@@ -11,6 +12,17 @@ from fabric_cli.core.fab_exceptions import FabricCLIError
 from fabric_cli.errors import ErrorMessages
 from fabric_cli.utils import fab_mem_store as utils_mem_store
 from fabric_cli.utils import fab_ui, fab_version_check
+
+AUTH_ENV_VARS = [
+    "FAB_TOKEN",
+    "FAB_TOKEN_ONELAKE",
+    "FAB_TOKEN_AZURE",
+    "FAB_SPN_CLIENT_ID",
+    "FAB_SPN_CLIENT_SECRET",
+    "FAB_SPN_CERT_PATH",
+    "FAB_SPN_FEDERATED_TOKEN",
+    "FAB_MANAGED_IDENTITY",
+]
 
 
 def init(args: Namespace) -> Any:
@@ -68,7 +80,7 @@ def init(args: Namespace) -> Any:
 
         try:
             if selected_auth == "Interactive with a web browser":
-                FabAuth().set_access_mode("user", args.tenant)
+                FabAuth().prepare_user_login(args.tenant)
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
@@ -206,6 +218,47 @@ def init(args: Namespace) -> Any:
 
 
 def logout(args: Namespace) -> None:
+    auth = FabAuth()
+
+    if getattr(args, "all", False):
+        auth.logout()
+
+        # Clear cache and context including current and stale context files
+        utils_mem_store.clear_caches()
+        Context().reset_context()
+
+        fab_ui.print_output_format(args, message="Logged out of Fabric account")
+        return
+
+    if auth.get_identity_type() == "user":
+        sessions = auth.get_user_sessions()
+        if sessions:
+            session = _resolve_user_session(
+                auth,
+                username=getattr(args, "username", None),
+                tenant_id=getattr(args, "tenant", None),
+                action="log out",
+            )
+            next_session = auth.remove_user_session(session["session_id"])
+
+            utils_mem_store.clear_caches()
+            if next_session is None:
+                Context().reset_context()
+                fab_ui.print_output_format(
+                    args,
+                    message=f"Logged out of {session['account_name']}",
+                )
+            else:
+                Context().context = auth.get_tenant()
+                fab_ui.print_output_format(
+                    args,
+                    message=(
+                        f"Logged out of {session['account_name']} and switched to "
+                        f"{next_session['account_name']}"
+                    ),
+                )
+            return
+
     FabAuth().logout()
 
     # Clear cache and context including current and stale context files
@@ -284,6 +337,138 @@ def status(args: Namespace) -> None:
         "token_azure": azure_secret,
     }
     fab_ui.print_output_format(args, data=auth_data, show_key_value_list=True)
+
+
+def list_accounts(args: Namespace) -> None:
+    auth = FabAuth()
+    sessions = auth.get_user_sessions()
+
+    if not sessions:
+        fab_ui.print_output_format(
+            args,
+            message=ErrorMessages.Auth.no_user_sessions_found(),
+        )
+        return
+
+    active_session = auth.get_active_user_session()
+    active_session_id = active_session.get("session_id") if active_session else None
+
+    rows = []
+    for session in sessions:
+        rows.append(
+            {
+                "active": str(session.get("session_id") == active_session_id).lower(),
+                "account": session.get("account_name", "Unknown"),
+                "tenant_id": session.get("tenant_id", "Unknown"),
+                "valid": str(auth.is_user_session_valid(session)).lower(),
+                "last_used_at": session.get("last_used_at", ""),
+            }
+        )
+
+    fab_ui.print_output_format(args, data=rows, show_headers=True)
+
+
+def switch(args: Namespace) -> None:
+    if _is_environment_auth_active():
+        raise FabricCLIError(
+            ErrorMessages.Auth.environment_auth_switch_not_supported(),
+            fab_constant.ERROR_INVALID_OPERATION,
+        )
+
+    auth = FabAuth()
+    session = _resolve_user_session(
+        auth,
+        username=getattr(args, "username", None),
+        tenant_id=getattr(args, "tenant", None),
+        action="switch to",
+        require_valid=True,
+    )
+    current_session = auth.get_active_user_session()
+
+    auth.activate_user_session(session["session_id"])
+    utils_mem_store.clear_caches()
+    Context().context = auth.get_tenant()
+
+    if current_session and current_session.get("session_id") == session.get(
+        "session_id"
+    ):
+        message = (
+            f"Already using {session['account_name']} in tenant {session['tenant_id']}"
+        )
+    else:
+        message = (
+            f"Switched to {session['account_name']} in tenant {session['tenant_id']}"
+        )
+
+    fab_ui.print_output_format(args, message=message)
+
+
+def _is_environment_auth_active() -> bool:
+    return any(os.environ.get(var) for var in AUTH_ENV_VARS)
+
+
+def _resolve_user_session(
+    auth: FabAuth,
+    username: Optional[str],
+    tenant_id: Optional[str],
+    action: str,
+    require_valid: bool = False,
+) -> dict[str, Any]:
+    sessions = auth.get_user_sessions()
+    if not sessions:
+        raise FabricCLIError(
+            ErrorMessages.Auth.no_user_sessions_found(),
+            fab_constant.ERROR_NOT_FOUND,
+        )
+
+    active_session = auth.get_active_user_session()
+    active_session_id = active_session.get("session_id") if active_session else None
+
+    candidates = []
+    for session in sessions:
+        if username and session.get("account_name") != username:
+            continue
+        if tenant_id and session.get("tenant_id") != tenant_id:
+            continue
+        if require_valid and not auth.is_user_session_valid(session):
+            continue
+        candidates.append(session)
+
+    if not candidates:
+        if require_valid:
+            error_message = (
+                "No valid stored user sessions matched the requested selection"
+            )
+        else:
+            error_message = ErrorMessages.Auth.no_user_sessions_found()
+        raise FabricCLIError(error_message, fab_constant.ERROR_NOT_FOUND)
+
+    if len(candidates) == 1:
+        return candidates[0]
+
+    if not username and not tenant_id and len(candidates) == 2:
+        for session in candidates:
+            if session.get("session_id") != active_session_id:
+                return session
+
+    prompt_map = {}
+    for session in candidates:
+        label = f"{session.get('account_name', 'Unknown')} ({session.get('tenant_id', 'Unknown')})"
+        if session.get("session_id") == active_session_id:
+            label += " [active]"
+        prompt_map[label] = session
+
+    selected_label = fab_ui.prompt_select_item(
+        f"Which account would you like to {action}?",
+        list(prompt_map.keys()),
+    )
+    if selected_label is None:
+        raise FabricCLIError(
+            "Operation cancelled",
+            fab_constant.ERROR_OPERATION_CANCELLED,
+        )
+
+    return prompt_map[selected_label]
 
 
 # Utils

--- a/src/fabric_cli/commands/auth/fab_auth.py
+++ b/src/fabric_cli/commands/auth/fab_auth.py
@@ -356,14 +356,21 @@ def list_accounts(args: Namespace) -> None:
     active_session = auth.get_active_user_session()
     active_session_id = active_session.get("session_id") if active_session else None
 
+    # Cache one MSAL app per tenant to avoid redundant app creation during validation.
+    tenant_apps: dict[str, Any] = {}
     rows = []
     for session in sessions:
+        tid = session.get("tenant_id")
+        if tid not in tenant_apps:
+            tenant_apps[tid] = auth._create_user_app(tid)
         rows.append(
             {
                 "active": str(session.get("session_id") == active_session_id).lower(),
                 "account": session.get("account_name", "Unknown"),
                 "tenant_id": session.get("tenant_id", "Unknown"),
-                "valid": str(auth.is_user_session_valid(session)).lower(),
+                "valid": str(
+                    auth.is_user_session_valid(session, app=tenant_apps[tid])
+                ).lower(),
                 "last_used_at": session.get("last_used_at", ""),
             }
         )
@@ -428,8 +435,9 @@ def _resolve_user_session(
     active_session_id = active_session.get("session_id") if active_session else None
 
     candidates = []
+    username_lower = username.lower() if username else None
     for session in sessions:
-        if username and session.get("account_name") != username:
+        if username_lower and (session.get("account_name") or "").lower() != username_lower:
             continue
         if tenant_id and session.get("tenant_id") != tenant_id:
             continue

--- a/src/fabric_cli/commands/auth/fab_auth.py
+++ b/src/fabric_cli/commands/auth/fab_auth.py
@@ -80,14 +80,18 @@ def init(args: Namespace) -> Any:
 
         try:
             if selected_auth == "Interactive with a web browser":
-                FabAuth().prepare_user_login(args.tenant)
-                FabAuth().get_access_token(
-                    scope=fab_constant.SCOPE_FABRIC_DEFAULT,
-                    force_interactive=True,
-                )
-                FabAuth().get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
-                FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
-                Context().context = FabAuth().get_tenant()
+                auth = FabAuth()
+                auth.prepare_user_login(args.tenant)
+                try:
+                    auth.get_access_token(
+                        scope=fab_constant.SCOPE_FABRIC_DEFAULT,
+                        force_interactive=True,
+                    )
+                    auth.get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
+                    auth.get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
+                finally:
+                    auth.finish_user_login()
+                Context().context = auth.get_tenant()
             elif selected_auth.startswith("Service principal authentication"):
                 fab_logger.log_warning(
                     "Ensure tenant setting is enabled for Service Principal auth"
@@ -437,7 +441,10 @@ def _resolve_user_session(
     candidates = []
     username_lower = username.lower() if username else None
     for session in sessions:
-        if username_lower and (session.get("account_name") or "").lower() != username_lower:
+        if (
+            username_lower
+            and (session.get("account_name") or "").lower() != username_lower
+        ):
             continue
         if tenant_id and session.get("tenant_id") != tenant_id:
             continue

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -55,6 +55,7 @@ class FabAuth:
         self.aad_public_key = None
         # Reset the auth info
         self.app: msal.ClientApplication = None
+        self._preserve_user_app_during_login = False
         self._auth_info = {}
 
         # Load the auth info and environment variables
@@ -265,7 +266,9 @@ class FabAuth:
             )
         except TypeError as e:
             # MSAL may not accept a username filter in all broker configurations.
-            fab_logger.log_debug(f"Filtered get_accounts failed, retrying unfiltered: {e}")
+            fab_logger.log_debug(
+                f"Filtered get_accounts failed, retrying unfiltered: {e}"
+            )
             accounts = app.get_accounts()
 
         if not isinstance(accounts, list):
@@ -476,7 +479,10 @@ class FabAuth:
         # Only reset the MSAL app when the tenant changes so that the active
         # WAM broker session is preserved during the login flow.
         new_tenant = session.get("tenant_id")
-        if self._auth_info.get(con.FAB_TENANT_ID) != new_tenant:
+        if (
+            not self._preserve_user_app_during_login
+            and self._auth_info.get(con.FAB_TENANT_ID) != new_tenant
+        ):
             self.app = None
         self._auth_info[con.IDENTITY_TYPE] = "user"
         self._auth_info[con.FAB_TENANT_ID] = new_tenant
@@ -799,10 +805,15 @@ class FabAuth:
     def set_tenant(self, tenant_id):
         if tenant_id is not None:
             if self.get_identity_type() == "user":
+                current_tenant_id = self.get_tenant_id()
                 # Only reset the MSAL app when the tenant actually changes so
                 # that the active WAM broker session is preserved across scope
                 # requests during login.
-                if self.get_tenant_id() != tenant_id:
+                if (
+                    not self._preserve_user_app_during_login
+                    and current_tenant_id is not None
+                    and current_tenant_id != tenant_id
+                ):
                     self.app = None
                 self._set_auth_properties(
                     {
@@ -827,7 +838,11 @@ class FabAuth:
 
     def prepare_user_login(self, tenant_id: Optional[str] = None) -> None:
         self.set_access_mode("user", tenant_id)
+        self._preserve_user_app_during_login = True
         self.app = self._create_user_app(tenant_id)
+
+    def finish_user_login(self) -> None:
+        self._preserve_user_app_during_login = False
 
     def set_spn(self, client_id, password=None, cert_path=None, client_assertion=None):
         persistence = self._get_persistence()
@@ -961,9 +976,14 @@ class FabAuth:
                 "access_token": env_var_token,
             }
         elif identity_type == "user":
-            self._ensure_current_user_session_loaded()
             account = None
-            active_session = self.get_active_user_session()
+            active_session = None
+            use_active_session = not self._preserve_user_app_during_login
+
+            if use_active_session:
+                self._ensure_current_user_session_loaded()
+                active_session = self.get_active_user_session()
+
             if not force_interactive:
                 # Use the cache to get the token unless login explicitly asked for account selection.
                 if active_session is not None:
@@ -997,7 +1017,12 @@ class FabAuth:
                     self.set_tenant(token.get("id_token_claims")["tid"])
                     if session is not None:
                         self._persist_user_session(session)
-            elif token and active_session is not None and not force_interactive:
+            elif (
+                token
+                and active_session is not None
+                and not force_interactive
+                and use_active_session
+            ):
                 # Silent acquisition succeeded — update the session timestamp.
                 self._persist_user_session(active_session)
 
@@ -1053,6 +1078,7 @@ class FabAuth:
         self._auth_info = {}
 
         self.app = None
+        self._preserve_user_app_during_login = False
 
         if os.path.exists(self.cache_file):
             os.remove(self.cache_file)

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -5,7 +5,7 @@ import json
 import os
 import uuid
 from binascii import hexlify
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, NamedTuple, Optional
 
 import jwt
@@ -263,7 +263,9 @@ class FabAuth:
             accounts = (
                 app.get_accounts(account_name) if account_name else app.get_accounts()
             )
-        except TypeError:
+        except TypeError as e:
+            # MSAL may not accept a username filter in all broker configurations.
+            fab_logger.log_debug(f"Filtered get_accounts failed, retrying unfiltered: {e}")
             accounts = app.get_accounts()
 
         if not isinstance(accounts, list):
@@ -295,7 +297,8 @@ class FabAuth:
         if tenant_id:
             try:
                 all_accounts = app.get_accounts()
-            except TypeError:
+            except TypeError as e:
+                fab_logger.log_debug(f"get_accounts failed during tenant fallback: {e}")
                 all_accounts = []
 
             if not isinstance(all_accounts, list):
@@ -361,7 +364,12 @@ class FabAuth:
 
     @staticmethod
     def _utc_now() -> str:
-        return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+        return (
+            datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
 
     def _build_user_session(
         self,
@@ -465,9 +473,13 @@ class FabAuth:
                 self._save_auth()
             return None
 
-        self.app = None
+        # Only reset the MSAL app when the tenant changes so that the active
+        # WAM broker session is preserved during the login flow.
+        new_tenant = session.get("tenant_id")
+        if self._auth_info.get(con.FAB_TENANT_ID) != new_tenant:
+            self.app = None
         self._auth_info[con.IDENTITY_TYPE] = "user"
-        self._auth_info[con.FAB_TENANT_ID] = session.get("tenant_id")
+        self._auth_info[con.FAB_TENANT_ID] = new_tenant
         self._auth_info[ACTIVE_USER_ACCOUNT_NAME_KEY] = session.get("account_name")
 
         if session.get("home_account_id"):
@@ -619,9 +631,14 @@ class FabAuth:
         self._save_auth()
         return self._find_user_session()
 
-    def is_user_session_valid(self, session: dict[str, Any]) -> bool:
+    def is_user_session_valid(
+        self,
+        session: dict[str, Any],
+        app: Optional[msal.PublicClientApplication] = None,
+    ) -> bool:
         try:
-            app = self._create_user_app(session.get("tenant_id"))
+            if app is None:
+                app = self._create_user_app(session.get("tenant_id"))
             account = self._get_matching_account(app, session)
             if account is None:
                 return False
@@ -782,7 +799,11 @@ class FabAuth:
     def set_tenant(self, tenant_id):
         if tenant_id is not None:
             if self.get_identity_type() == "user":
-                self.app = None
+                # Only reset the MSAL app when the tenant actually changes so
+                # that the active WAM broker session is preserved across scope
+                # requests during login.
+                if self.get_tenant_id() != tenant_id:
+                    self.app = None
                 self._set_auth_properties(
                     {
                         con.FAB_TENANT_ID: tenant_id,
@@ -959,6 +980,8 @@ class FabAuth:
                     scopes=scope, account=account
                 )
 
+            # When force_interactive=True the silent block above is skipped so token
+            # remains None, falling through here to trigger the interactive prompt.
             if token is None and interactive_renew and identity_type == "user":
                 token = self._get_app().acquire_token_interactive(
                     scopes=scope,
@@ -975,6 +998,7 @@ class FabAuth:
                     if session is not None:
                         self._persist_user_session(session)
             elif token and active_session is not None and not force_interactive:
+                # Silent acquisition succeeded — update the session timestamp.
                 self._persist_user_session(active_session)
 
         if token and token.get("error"):

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -5,6 +5,7 @@ import json
 import os
 import uuid
 from binascii import hexlify
+from datetime import datetime
 from typing import Any, NamedTuple, Optional
 
 import jwt
@@ -26,6 +27,11 @@ from fabric_cli.core.fab_exceptions import FabricCLIError
 from fabric_cli.core.hiearchy.fab_tenant import Tenant
 from fabric_cli.errors import ErrorMessages
 from fabric_cli.utils import fab_ui as utils_ui
+
+USER_SESSIONS_KEY = "user_sessions"
+ACTIVE_USER_SESSION_ID_KEY = "active_user_session_id"
+ACTIVE_USER_ACCOUNT_NAME_KEY = "active_user_account_name"
+ACTIVE_USER_ACCOUNT_HOME_ID_KEY = "active_user_account_home_id"
 
 
 def singleton(class_):
@@ -197,6 +203,434 @@ class FabAuth:
                 decoded_dict[key] = value
         return decoded_dict
 
+    def _remove_auth_property(self, key: str) -> None:
+        if key in self._auth_info:
+            del self._auth_info[key]
+
+    def _get_user_sessions(self) -> list[dict[str, Any]]:
+        sessions = self._auth_info.get(USER_SESSIONS_KEY, [])
+        if not isinstance(sessions, list):
+            return []
+        return [session for session in sessions if isinstance(session, dict)]
+
+    def _save_user_sessions(self, sessions: list[dict[str, Any]]) -> None:
+        if sessions:
+            self._auth_info[USER_SESSIONS_KEY] = sessions
+        else:
+            self._remove_auth_property(USER_SESSIONS_KEY)
+
+    def _get_active_user_session_id(self) -> Optional[str]:
+        return self._auth_info.get(ACTIVE_USER_SESSION_ID_KEY)
+
+    def _build_user_session_id(
+        self,
+        account_name: str,
+        tenant_id: Optional[str],
+        home_account_id: Optional[str],
+    ) -> str:
+        if home_account_id:
+            return home_account_id
+        if tenant_id:
+            return f"{account_name}|{tenant_id}"
+        return account_name
+
+    def _create_user_app(
+        self, tenant_id: Optional[str]
+    ) -> msal.PublicClientApplication:
+        persistence = self._get_persistence()
+        cache = PersistedTokenCache(persistence)
+        authority = (
+            con.AUTH_DEFAULT_AUTHORITY
+            if tenant_id is None
+            else f"{con.AUTH_TENANT_AUTHORITY}{tenant_id}"
+        )
+        return msal.PublicClientApplication(
+            client_id=con.AUTH_DEFAULT_CLIENT_ID,
+            authority=authority,
+            token_cache=cache,
+            enable_broker_on_windows=True,
+        )
+
+    def _get_matching_account(
+        self,
+        app: msal.PublicClientApplication,
+        session: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        account_name = session.get("account_name")
+        tenant_id = session.get("tenant_id")
+
+        try:
+            accounts = (
+                app.get_accounts(account_name) if account_name else app.get_accounts()
+            )
+        except TypeError:
+            accounts = app.get_accounts()
+
+        if not isinstance(accounts, list):
+            return None
+
+        for account in accounts:
+            if (
+                session.get("home_account_id")
+                and account.get("home_account_id") == session["home_account_id"]
+            ):
+                return account
+
+        for account in accounts:
+            if (
+                session.get("local_account_id")
+                and account.get("local_account_id") == session["local_account_id"]
+                and (tenant_id is None or account.get("realm") == tenant_id)
+            ):
+                return account
+
+        for account in accounts:
+            if (
+                account_name
+                and account.get("username") == account_name
+                and (tenant_id is None or account.get("realm") == tenant_id)
+            ):
+                return account
+
+        if tenant_id:
+            try:
+                all_accounts = app.get_accounts()
+            except TypeError:
+                all_accounts = []
+
+            if not isinstance(all_accounts, list):
+                all_accounts = []
+
+            for account in all_accounts:
+                if account.get("realm") == tenant_id:
+                    return account
+
+        return accounts[0] if accounts else None
+
+    def _build_current_user_session_from_cache(self) -> Optional[dict[str, Any]]:
+        if self.get_identity_type() != "user":
+            return None
+
+        try:
+            app = self.app if self.app is not None else self._get_app()
+        except Exception:
+            return None
+
+        if not hasattr(app, "get_accounts"):
+            return None
+
+        try:
+            accounts = app.get_accounts()
+        except TypeError:
+            return None
+
+        if not isinstance(accounts, list):
+            return None
+
+        if not accounts:
+            return None
+
+        account = None
+        tenant_id = self.get_tenant_id()
+        if tenant_id:
+            for candidate in accounts:
+                if candidate.get("realm") == tenant_id:
+                    account = candidate
+                    break
+
+        if account is None:
+            account = accounts[0]
+
+        account_name = account.get("username") or "Unknown"
+        home_account_id = account.get("home_account_id")
+        local_account_id = account.get("local_account_id")
+        tenant_id = account.get("realm") or tenant_id
+        timestamp = self._utc_now()
+
+        return {
+            "session_id": self._build_user_session_id(
+                account_name, tenant_id, home_account_id
+            ),
+            "account_name": account_name,
+            "home_account_id": home_account_id,
+            "local_account_id": local_account_id,
+            "tenant_id": tenant_id,
+            "created_at": timestamp,
+            "last_used_at": timestamp,
+        }
+
+    @staticmethod
+    def _utc_now() -> str:
+        return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+    def _build_user_session(
+        self,
+        token_result: dict[str, Any],
+        fallback_tenant_id: Optional[str] = None,
+        app: Optional[Any] = None,
+    ) -> Optional[dict[str, Any]]:
+        id_token_claims = token_result.get("id_token_claims", {}) or {}
+        token_claims: dict[str, Any] = {}
+
+        if token_result.get("access_token"):
+            try:
+                token_claims = (
+                    self._get_claims_from_token(
+                        token_result["access_token"],
+                        ["upn", "preferred_username", "oid", "tid"],
+                    )
+                    or {}
+                )
+            except FabricCLIError:
+                token_claims = {}
+
+        tenant_id = (
+            id_token_claims.get("tid")
+            or token_claims.get("tid")
+            or fallback_tenant_id
+            or self.get_tenant_id()
+        )
+        account_name = (
+            id_token_claims.get("preferred_username")
+            or id_token_claims.get("upn")
+            or token_claims.get("preferred_username")
+            or token_claims.get("upn")
+        )
+        local_account_id = id_token_claims.get("oid") or token_claims.get("oid")
+
+        if app is None:
+            try:
+                app = (
+                    self.app
+                    if self.app is not None
+                    else self._create_user_app(tenant_id)
+                )
+            except Exception:
+                return None
+
+        if not hasattr(app, "get_accounts"):
+            return None
+
+        account = self._get_matching_account(
+            app,
+            {
+                "account_name": account_name,
+                "local_account_id": local_account_id,
+                "tenant_id": tenant_id,
+            },
+        )
+        if account is None:
+            return None
+
+        account_name = account.get("username") or account_name or "Unknown"
+        home_account_id = account.get("home_account_id")
+        local_account_id = account.get("local_account_id") or local_account_id
+        tenant_id = account.get("realm") or tenant_id
+        timestamp = self._utc_now()
+
+        return {
+            "session_id": self._build_user_session_id(
+                account_name, tenant_id, home_account_id
+            ),
+            "account_name": account_name,
+            "home_account_id": home_account_id,
+            "local_account_id": local_account_id,
+            "tenant_id": tenant_id,
+            "created_at": timestamp,
+            "last_used_at": timestamp,
+        }
+
+    def _find_user_session(
+        self, session_id: Optional[str] = None
+    ) -> Optional[dict[str, Any]]:
+        if session_id is None:
+            session_id = self._get_active_user_session_id()
+
+        if session_id is None:
+            return None
+
+        for session in self._get_user_sessions():
+            if session.get("session_id") == session_id:
+                return session
+
+        return None
+
+    def _sync_active_user_session(self, save: bool = True) -> Optional[dict[str, Any]]:
+        session = self._find_user_session()
+        if session is None:
+            self._remove_auth_property(ACTIVE_USER_SESSION_ID_KEY)
+            self._remove_auth_property(ACTIVE_USER_ACCOUNT_NAME_KEY)
+            self._remove_auth_property(ACTIVE_USER_ACCOUNT_HOME_ID_KEY)
+            if save:
+                self._save_auth()
+            return None
+
+        self.app = None
+        self._auth_info[con.IDENTITY_TYPE] = "user"
+        self._auth_info[con.FAB_TENANT_ID] = session.get("tenant_id")
+        self._auth_info[ACTIVE_USER_ACCOUNT_NAME_KEY] = session.get("account_name")
+
+        if session.get("home_account_id"):
+            self._auth_info[ACTIVE_USER_ACCOUNT_HOME_ID_KEY] = session.get(
+                "home_account_id"
+            )
+        else:
+            self._remove_auth_property(ACTIVE_USER_ACCOUNT_HOME_ID_KEY)
+
+        self._remove_auth_property(con.FAB_SPN_CLIENT_ID)
+
+        if save:
+            self._save_auth()
+
+        return session
+
+    def _persist_user_session(
+        self, session: dict[str, Any], set_active: bool = True
+    ) -> None:
+        sessions = self._get_user_sessions()
+        existing_session = None
+
+        for stored_session in sessions:
+            if stored_session.get("session_id") == session.get("session_id"):
+                existing_session = stored_session
+                break
+
+        timestamp = self._utc_now()
+        session["created_at"] = (
+            existing_session.get("created_at")
+            if existing_session
+            else session.get("created_at", timestamp)
+        )
+        session["last_used_at"] = timestamp
+
+        if existing_session:
+            sessions = [
+                session if item.get("session_id") == session.get("session_id") else item
+                for item in sessions
+            ]
+        else:
+            sessions.append(session)
+
+        self._save_user_sessions(sessions)
+
+        if set_active:
+            self._auth_info[ACTIVE_USER_SESSION_ID_KEY] = session.get("session_id")
+            self._sync_active_user_session(save=False)
+
+        self._save_auth()
+
+    def _ensure_current_user_session_loaded(self) -> None:
+        if self.get_identity_type() != "user":
+            return
+
+        sessions = self._get_user_sessions()
+        active_session = self._find_user_session()
+
+        if sessions and active_session is not None:
+            return
+
+        if sessions:
+            self._auth_info[ACTIVE_USER_SESSION_ID_KEY] = sessions[0].get("session_id")
+            self._sync_active_user_session()
+            return
+
+        current_session = self._build_current_user_session_from_cache()
+        if current_session is None:
+            return
+
+        self._persist_user_session(current_session)
+
+    def get_user_sessions(self) -> list[dict[str, Any]]:
+        self._ensure_current_user_session_loaded()
+        active_session_id = self._get_active_user_session_id()
+        return sorted(
+            self._get_user_sessions(),
+            key=lambda session: (
+                session.get("session_id") == active_session_id,
+                session.get("last_used_at", ""),
+            ),
+            reverse=True,
+        )
+
+    def get_active_user_session(self) -> Optional[dict[str, Any]]:
+        self._ensure_current_user_session_loaded()
+        return self._find_user_session()
+
+    def activate_user_session(self, session_id: str) -> dict[str, Any]:
+        self._ensure_current_user_session_loaded()
+
+        session = self._find_user_session(session_id)
+        if session is None:
+            raise FabricCLIError(
+                ErrorMessages.Auth.user_session_not_found(session_id),
+                con.ERROR_NOT_FOUND,
+            )
+
+        session["last_used_at"] = self._utc_now()
+        self._save_user_sessions(
+            [
+                session if item.get("session_id") == session_id else item
+                for item in self._get_user_sessions()
+            ]
+        )
+        self._auth_info[ACTIVE_USER_SESSION_ID_KEY] = session_id
+        self._sync_active_user_session(save=False)
+        self._save_auth()
+        return session
+
+    def remove_user_session(self, session_id: str) -> Optional[dict[str, Any]]:
+        self._ensure_current_user_session_loaded()
+
+        sessions = self._get_user_sessions()
+        session = self._find_user_session(session_id)
+        if session is None:
+            raise FabricCLIError(
+                ErrorMessages.Auth.user_session_not_found(session_id),
+                con.ERROR_NOT_FOUND,
+            )
+
+        app = self._create_user_app(session.get("tenant_id"))
+        account = self._get_matching_account(app, session)
+        if account is not None:
+            app.remove_account(account)
+
+        self.app = None
+        sessions = [
+            item
+            for item in sessions
+            if item.get("session_id") != session.get("session_id")
+        ]
+
+        if not sessions:
+            self.logout()
+            return None
+
+        self._save_user_sessions(sessions)
+
+        if self._get_active_user_session_id() == session_id:
+            next_session = sorted(
+                sessions,
+                key=lambda item: item.get("last_used_at", ""),
+                reverse=True,
+            )[0]
+            self._auth_info[ACTIVE_USER_SESSION_ID_KEY] = next_session.get("session_id")
+            self._sync_active_user_session(save=False)
+
+        self._save_auth()
+        return self._find_user_session()
+
+    def is_user_session_valid(self, session: dict[str, Any]) -> bool:
+        try:
+            app = self._create_user_app(session.get("tenant_id"))
+            account = self._get_matching_account(app, session)
+            if account is None:
+                return False
+
+            token = app.acquire_token_silent(con.SCOPE_FABRIC_DEFAULT, account=account)
+            return bool(token and token.get("access_token"))
+        except Exception:
+            return False
+
     def _get_persistence(self):
         persistence = None
         try:
@@ -328,14 +762,34 @@ class FabAuth:
                 ),
                 status_code=con.ERROR_INVALID_ACCESS_MODE,
             )
+
+        if mode == "user":
+            if self.get_identity_type() not in [None, "user"]:
+                self.logout()
+            if tenant_id:
+                self.set_tenant(tenant_id)
+            self.app = None
+            self._set_auth_property(con.IDENTITY_TYPE, mode)
+            return
+
         if mode != self.get_identity_type():
             self.logout()
         if tenant_id and self.get_tenant_id() != tenant_id:
             self.set_tenant(tenant_id)
+        self.app = None
         self._set_auth_property(con.IDENTITY_TYPE, mode)
 
     def set_tenant(self, tenant_id):
         if tenant_id is not None:
+            if self.get_identity_type() == "user":
+                self.app = None
+                self._set_auth_properties(
+                    {
+                        con.FAB_TENANT_ID: tenant_id,
+                    }
+                )
+                return
+
             current_tenant_id = self.get_tenant_id()
             if current_tenant_id is not None and current_tenant_id != tenant_id:
                 fab_logger.log_warning(
@@ -349,6 +803,10 @@ class FabAuth:
                     con.FAB_TENANT_ID: tenant_id,
                 }
             )
+
+    def prepare_user_login(self, tenant_id: Optional[str] = None) -> None:
+        self.set_access_mode("user", tenant_id)
+        self.app = self._create_user_app(tenant_id)
 
     def set_spn(self, client_id, password=None, cert_path=None, client_assertion=None):
         persistence = self._get_persistence()
@@ -432,18 +890,18 @@ class FabAuth:
     def acquire_token(self, scope: list[str], interactive_renew=True) -> dict:
         """
         Core MSAL token acquisition method that returns the full MSAL result.
-        
+
         This method contains the common authentication logic shared between
         get_access_token and msal_bridge.get_token. It performs no validation
         on scopes - callers are responsible for their own validation needs.
-        
+
         Args:
             scope: The scopes for which to request the token
             interactive_renew: Whether to allow interactive authentication for user flows
-            
+
         Returns:
             Full MSAL result dictionary containing access_token, expires_on, etc.
-            
+
         Raises:
             FabricCLIError: When token acquisition fails
         """
@@ -476,11 +934,18 @@ class FabAuth:
                 "access_token": env_var_token,
             }
         elif identity_type == "user":
+            self._ensure_current_user_session_loaded()
             # Use the cache to get the token
-            accounts = self._get_app().get_accounts()
             account = None
-            if accounts:
-                account = accounts[0]
+            active_session = self.get_active_user_session()
+            if active_session is not None:
+                account = self._get_matching_account(self._get_app(), active_session)
+
+            if account is None:
+                accounts = self._get_app().get_accounts()
+                if accounts:
+                    account = accounts[0]
+
             token = self._get_app().acquire_token_silent(scopes=scope, account=account)
 
             if token is None and interactive_renew and identity_type == "user":
@@ -490,14 +955,25 @@ class FabAuth:
                     parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
                 )
                 if token is not None and "id_token_claims" in token:
+                    session = self._build_user_session(
+                        token,
+                        fallback_tenant_id=token.get("id_token_claims", {}).get("tid"),
+                        app=self._get_app(),
+                    )
                     self.set_tenant(token.get("id_token_claims")["tid"])
+                    if session is not None:
+                        self._persist_user_session(session)
+            elif token and active_session is not None:
+                self._persist_user_session(active_session)
 
         if token and token.get("error"):
             fab_logger.log_debug(
-                f"Error in get token: {token.get('error_description')}")
+                f"Error in get token: {token.get('error_description')}"
+            )
             raise FabricCLIError(
                 ErrorMessages.Auth.access_token_error(
-                    "Something went wrong while trying to acquire a token. Please try to run `fab auth logout` and then `fab auth login` to re-login and acquire new tokens."),
+                    "Something went wrong while trying to acquire a token. Please try to run `fab auth logout` and then `fab auth login` to re-login and acquire new tokens."
+                ),
                 status_code=con.ERROR_AUTHENTICATION_FAILED,
             )
         if token is None or not token.get("access_token"):
@@ -511,17 +987,17 @@ class FabAuth:
     def get_access_token(self, scope: list[str], interactive_renew=True) -> str | None:
         """
         Get an access token string for the specified scopes.
-        
+
         This method maintains the existing CLI API - returns just the token string
         for backward compatibility. Uses the shared acquire_token method internally.
-        
+
         Args:
             scope: The scopes for which to request the token
             interactive_renew: Whether to allow interactive authentication for user flows
-            
+
         Returns:
             Access token string or None if acquisition fails
-            
+
         Raises:
             FabricCLIError: When token acquisition fails
         """
@@ -731,8 +1207,8 @@ class FabAuth:
         )
         cert = x509.load_pem_x509_certificate(certificate_data, default_backend())
         fingerprint = cert.fingerprint(
-            hashes.SHA1() # CodeQL [SM02167] SHA‑1 thumbprint is only a certificate identifier required by MSAL/Microsoft Entra, not a cryptographic operation
-        )  
+            hashes.SHA1()  # CodeQL [SM02167] SHA‑1 thumbprint is only a certificate identifier required by MSAL/Microsoft Entra, not a cryptographic operation
+        )
         return self._Cert(certificate_data, private_key, fingerprint)
 
     def _load_pkcs12_certificate(

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -887,7 +887,12 @@ class FabAuth:
                     status_code=con.ERROR_AUTHENTICATION_FAILED,
                 )
 
-    def acquire_token(self, scope: list[str], interactive_renew=True) -> dict:
+    def acquire_token(
+        self,
+        scope: list[str],
+        interactive_renew=True,
+        force_interactive: bool = False,
+    ) -> dict:
         """
         Core MSAL token acquisition method that returns the full MSAL result.
 
@@ -898,6 +903,7 @@ class FabAuth:
         Args:
             scope: The scopes for which to request the token
             interactive_renew: Whether to allow interactive authentication for user flows
+            force_interactive: Whether to skip silent acquisition and force an interactive user prompt
 
         Returns:
             Full MSAL result dictionary containing access_token, expires_on, etc.
@@ -935,18 +941,23 @@ class FabAuth:
             }
         elif identity_type == "user":
             self._ensure_current_user_session_loaded()
-            # Use the cache to get the token
             account = None
             active_session = self.get_active_user_session()
-            if active_session is not None:
-                account = self._get_matching_account(self._get_app(), active_session)
+            if not force_interactive:
+                # Use the cache to get the token unless login explicitly asked for account selection.
+                if active_session is not None:
+                    account = self._get_matching_account(
+                        self._get_app(), active_session
+                    )
 
-            if account is None:
-                accounts = self._get_app().get_accounts()
-                if accounts:
-                    account = accounts[0]
+                if account is None:
+                    accounts = self._get_app().get_accounts()
+                    if accounts:
+                        account = accounts[0]
 
-            token = self._get_app().acquire_token_silent(scopes=scope, account=account)
+                token = self._get_app().acquire_token_silent(
+                    scopes=scope, account=account
+                )
 
             if token is None and interactive_renew and identity_type == "user":
                 token = self._get_app().acquire_token_interactive(
@@ -963,7 +974,7 @@ class FabAuth:
                     self.set_tenant(token.get("id_token_claims")["tid"])
                     if session is not None:
                         self._persist_user_session(session)
-            elif token and active_session is not None:
+            elif token and active_session is not None and not force_interactive:
                 self._persist_user_session(active_session)
 
         if token and token.get("error"):
@@ -984,7 +995,12 @@ class FabAuth:
 
         return token
 
-    def get_access_token(self, scope: list[str], interactive_renew=True) -> str | None:
+    def get_access_token(
+        self,
+        scope: list[str],
+        interactive_renew=True,
+        force_interactive: bool = False,
+    ) -> str | None:
         """
         Get an access token string for the specified scopes.
 
@@ -994,6 +1010,7 @@ class FabAuth:
         Args:
             scope: The scopes for which to request the token
             interactive_renew: Whether to allow interactive authentication for user flows
+            force_interactive: Whether to skip silent acquisition and force an interactive user prompt
 
         Returns:
             Access token string or None if acquisition fails
@@ -1001,7 +1018,11 @@ class FabAuth:
         Raises:
             FabricCLIError: When token acquisition fails
         """
-        token_result = self.acquire_token(scope, interactive_renew)
+        token_result = self.acquire_token(
+            scope,
+            interactive_renew,
+            force_interactive=force_interactive,
+        )
         return token_result.get("access_token", None)
 
     def logout(self):

--- a/src/fabric_cli/errors/auth.py
+++ b/src/fabric_cli/errors/auth.py
@@ -85,6 +85,18 @@ class AuthErrors:
         return "Failed to obtain access token"
 
     @staticmethod
+    def no_user_sessions_found() -> str:
+        return "No stored user sessions found"
+
+    @staticmethod
+    def user_session_not_found(session_identifier: str) -> str:
+        return f"Stored user session '{session_identifier}' not found"
+
+    @staticmethod
+    def environment_auth_switch_not_supported() -> str:
+        return "Stored user sessions cannot be switched while authentication is controlled by environment variables"
+
+    @staticmethod
     def jwt_decode_failed() -> str:
         return "Failed to decode JWT token"
 

--- a/src/fabric_cli/main.py
+++ b/src/fabric_cli/main.py
@@ -16,14 +16,14 @@ from fabric_cli.utils.fab_commands import COMMANDS
 
 def main():
     parser, subparsers = get_global_parser_and_subparsers()
-    
+
     argcomplete.autocomplete(parser, default_completer=None)
 
     args = parser.parse_args()
 
     try:
         fab_state_config.init_defaults()
-        
+
         if args.command == "auth" and args.auth_command == None:
             auth_parser.show_help(args)
             return
@@ -41,16 +41,21 @@ def main():
                     start_interactive_mode()
                     return
 
-        if args.command == "auth" and args.auth_command == "logout":
+        if args.command == "auth" and args.auth_command in [
+            "logout",
+            "status",
+            "list",
+            "switch",
+        ]:
             from fabric_cli.commands.auth import fab_auth
 
-            fab_auth.logout(args)
-            return
-
-        if args.command == "auth" and args.auth_command == "status":
-            from fabric_cli.commands.auth import fab_auth
-
-            fab_auth.status(args)
+            auth_commands = {
+                "logout": fab_auth.logout,
+                "status": fab_auth.status,
+                "list": fab_auth.list_accounts,
+                "switch": fab_auth.switch,
+            }
+            auth_commands[args.auth_command](args)
             return
 
         last_exit_code = fab_constant.EXIT_CODE_SUCCESS
@@ -119,11 +124,11 @@ def _handle_unexpected_error(err, args):
         error_message = str(err.args[0]) if err.args else str(err)
     except:
         error_message = "An unexpected error occurred"
-    
+
     fab_ui.print_output_error(
-        FabricCLIError(error_message, fab_constant.ERROR_UNEXPECTED_ERROR), 
+        FabricCLIError(error_message, fab_constant.ERROR_UNEXPECTED_ERROR),
         output_format_type=args.output_format,
-        )
+    )
     sys.exit(fab_constant.EXIT_CODE_ERROR)
 
 
@@ -145,4 +150,3 @@ def _execute_command(args, subparsers, parser):
 
 if __name__ == "__main__":
     main()
-

--- a/src/fabric_cli/parsers/fab_auth_parser.py
+++ b/src/fabric_cli/parsers/fab_auth_parser.py
@@ -14,7 +14,9 @@ commands = {
     "Commands": {
         "login": "Log in to a Fabric account.",
         "logout": "End the current authentication session.",
+        "list": "List stored user authentication sessions.",
         "status": "Display active account and authentication state.",
+        "switch": "Switch the active stored user session.",
     },
 }
 
@@ -86,7 +88,7 @@ def register_parser(subparsers: _SubParsersAction) -> None:
     )
 
     login_parser.usage = f"{utils_error_parser.get_usage_prog(login_parser)}"
-    login_parser.set_defaults(func=lazy_command(_auth_module_path, 'init'))
+    login_parser.set_defaults(func=lazy_command(_auth_module_path, "init"))
 
     # Subcommand for 'logout'
     logout_examples = [
@@ -102,9 +104,44 @@ def register_parser(subparsers: _SubParsersAction) -> None:
         fab_examples=logout_examples,
         fab_learnmore=["_"],
     )
+    logout_parser.add_argument(
+        "-u",
+        "--username",
+        metavar="",
+        required=False,
+        help="Stored account name to log out. Optional.",
+    )
+    logout_parser.add_argument(
+        "-t",
+        "--tenant",
+        metavar="",
+        required=False,
+        help="Stored tenant ID to disambiguate the account. Optional.",
+    )
+    logout_parser.add_argument(
+        "--all",
+        action="store_true",
+        required=False,
+        help="Clear all stored authentication sessions.",
+    )
 
     logout_parser.usage = f"{utils_error_parser.get_usage_prog(logout_parser)}"
-    logout_parser.set_defaults(func=lazy_command(_auth_module_path, 'logout'))
+    logout_parser.set_defaults(func=lazy_command(_auth_module_path, "logout"))
+
+    list_examples = [
+        "# interactive mode",
+        "$ auth list\n",
+        "# command_line mode",
+        "$ fab auth list",
+    ]
+    list_parser = auth_subparsers.add_parser(
+        "list",
+        help="List stored authentication sessions.",
+        fab_examples=list_examples,
+        fab_learnmore=["_"],
+    )
+    list_parser.usage = f"{utils_error_parser.get_usage_prog(list_parser)}"
+    list_parser.set_defaults(func=lazy_command(_auth_module_path, "list_accounts"))
 
     # Subcommand for 'status'
     status_examples = [
@@ -121,7 +158,39 @@ def register_parser(subparsers: _SubParsersAction) -> None:
     )
 
     status_parser.usage = f"{utils_error_parser.get_usage_prog(status_parser)}"
-    status_parser.set_defaults(func=lazy_command(_auth_module_path, 'status'))
+    status_parser.set_defaults(func=lazy_command(_auth_module_path, "status"))
+
+    switch_examples = [
+        "# interactive mode",
+        "$ auth switch\n",
+        "# command_line mode",
+        "$ fab auth switch\n",
+        "# switch with explicit account and tenant",
+        "$ fab auth switch -u <account_name> -t <tenant_id>",
+    ]
+    switch_parser = auth_subparsers.add_parser(
+        "switch",
+        help="Switch the active stored authentication session.",
+        fab_examples=switch_examples,
+        fab_learnmore=["_"],
+    )
+    switch_parser.add_argument(
+        "-u",
+        "--username",
+        metavar="",
+        required=False,
+        help="Stored account name to switch to. Optional.",
+    )
+    switch_parser.add_argument(
+        "-t",
+        "--tenant",
+        metavar="",
+        required=False,
+        help="Stored tenant ID to disambiguate the account. Optional.",
+    )
+
+    switch_parser.usage = f"{utils_error_parser.get_usage_prog(switch_parser)}"
+    switch_parser.set_defaults(func=lazy_command(_auth_module_path, "switch"))
 
 
 def show_help(args: Namespace) -> None:

--- a/tests/test_commands/test_auth.py
+++ b/tests/test_commands/test_auth.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import argparse
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,6 +15,19 @@ from fabric_cli.core.fab_context import Context
 from fabric_cli.core.fab_exceptions import FabricCLIError
 from fabric_cli.core.hiearchy.fab_hiearchy import Tenant
 from fabric_cli.errors import ErrorMessages
+
+
+@pytest.fixture(autouse=True)
+def reset_fab_auth_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "fabric_cli.core.fab_state_config.config_location", lambda: str(tmp_path)
+    )
+    auth = FabAuth()
+    auth.auth_file = os.path.join(tmp_path, "auth.json")
+    auth.cache_file = os.path.join(tmp_path, "cache.bin")
+    auth._auth_info = {}
+    auth.app = None
+    auth.aad_public_key = None
 
 
 class TestAuth:
@@ -30,7 +44,7 @@ class TestAuth:
 
             # Assert
             mock_fab_auth_instance = mock_fab_auth.get("instance")
-            mock_fab_auth_instance.set_access_mode.assert_called_with("user", None)
+            mock_fab_auth_instance.prepare_user_login.assert_called_with(None)
             assert_get_access_token(mock_fab_auth_instance)
             assert result is True
 
@@ -53,9 +67,7 @@ class TestAuth:
 
             # Assert
             mock_fab_auth_instance = mock_fab_auth.get("instance")
-            mock_fab_auth_instance.set_access_mode.assert_called_with(
-                "user", "mock_tenant"
-            )
+            mock_fab_auth_instance.prepare_user_login.assert_called_with("mock_tenant")
             assert_get_access_token(mock_fab_auth_instance)
             assert result is True
 
@@ -928,10 +940,113 @@ class TestAuth:
             assert "mocked_tenant_id" in captured.out
             assert "mock************************************" in captured.out
 
+    def test_auth_list_accounts(self, mock_fab_auth):
+        args = argparse.Namespace(command="auth", output_format=None)
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.get_user_sessions.return_value = [
+            {
+                "session_id": "session-a",
+                "account_name": "alice@example.com",
+                "tenant_id": "tenant-a",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            },
+            {
+                "session_id": "session-b",
+                "account_name": "bob@example.com",
+                "tenant_id": "tenant-b",
+                "last_used_at": "2026-04-06T12:00:00Z",
+            },
+        ]
+        mock_fab_auth_instance.get_active_user_session.return_value = {
+            "session_id": "session-a"
+        }
+        mock_fab_auth_instance.is_user_session_valid.side_effect = [True, False]
+
+        with patch(
+            "fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"
+        ) as mock_print:
+            fab_auth.list_accounts(args)
+
+        mock_print.assert_called_once()
+        rows = mock_print.call_args.kwargs["data"]
+        assert rows[0]["account"] == "alice@example.com"
+        assert rows[0]["active"] == "true"
+        assert rows[0]["valid"] == "true"
+        assert rows[1]["account"] == "bob@example.com"
+        assert rows[1]["valid"] == "false"
+
+    def test_auth_switch(self, mock_fab_auth, mock_fab_context):
+        args = argparse.Namespace(
+            command="auth",
+            output_format=None,
+            username="bob@example.com",
+            tenant="tenant-b",
+        )
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.get_user_sessions.return_value = [
+            {
+                "session_id": "session-b",
+                "account_name": "bob@example.com",
+                "tenant_id": "tenant-b",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            }
+        ]
+        mock_fab_auth_instance.get_active_user_session.return_value = {
+            "session_id": "session-a",
+            "account_name": "alice@example.com",
+            "tenant_id": "tenant-a",
+        }
+
+        with patch(
+            "fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"
+        ) as mock_print:
+            fab_auth.switch(args)
+
+        mock_fab_auth_instance.activate_user_session.assert_called_once_with(
+            "session-b"
+        )
+        mock_fab_context_instance = mock_fab_context.get("instance")
+        assert mock_fab_context_instance.context == Tenant(
+            name="Unknown", id="mocked_tenant_id"
+        )
+        mock_print.assert_called_once()
+
+    def test_auth_logout_user_session(self, mock_fab_auth, mock_fab_context):
+        args = argparse.Namespace(
+            command="auth",
+            output_format=None,
+            username="alice@example.com",
+            tenant="tenant-a",
+            all=False,
+        )
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.get_identity_type = MagicMock(return_value="user")
+        mock_fab_auth_instance.get_user_sessions.return_value = [
+            {
+                "session_id": "session-a",
+                "account_name": "alice@example.com",
+                "tenant_id": "tenant-a",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            }
+        ]
+        mock_fab_auth_instance.get_active_user_session.return_value = {
+            "session_id": "session-a"
+        }
+        mock_fab_auth_instance.remove_user_session.return_value = None
+
+        with patch(
+            "fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"
+        ) as mock_print:
+            fab_auth.logout(args)
+
+        mock_fab_auth_instance.remove_user_session.assert_called_once_with("session-a")
+        mock_fab_context_instance = mock_fab_context.get("instance")
+        mock_fab_context_instance.reset_context.assert_called_once()
+        mock_print.assert_called_once()
+
     def test_init_when_user_cancels_the_prompt(
         self, mock_fab_auth, mock_fab_context, mock_fab_logger_log_warning, capsys
     ):
-
         # Arrange
         with patch(
             "fabric_cli.utils.fab_ui.prompt_select_item",
@@ -979,6 +1094,7 @@ def prepare_auth_args(args=None):
 def assert_fab_auth_not_called(mock_fab_auth):
     mock_fab_auth_instance = mock_fab_auth.get("instance")
     mock_fab_auth_instance.set_access_mode.assert_not_called()
+    mock_fab_auth_instance.prepare_user_login.assert_not_called()
     mock_fab_auth_instance.set_tenant.assert_not_called()
     mock_fab_auth_instance.set_spn.assert_not_called()
     mock_fab_auth_instance.get_access_token.assert_not_called()
@@ -1014,7 +1130,13 @@ def mock_fab_auth():
         fab_auth_instance,
         get_access_token=MagicMock(return_value="mocked_access_token"),
         get_tenant_id=MagicMock(return_value="mocked_tenant_id"),
+        get_user_sessions=MagicMock(return_value=[]),
+        get_active_user_session=MagicMock(return_value=None),
+        remove_user_session=MagicMock(return_value=None),
+        activate_user_session=MagicMock(),
+        is_user_session_valid=MagicMock(return_value=True),
         set_access_mode=MagicMock(),
+        prepare_user_login=MagicMock(),
         set_tenant=MagicMock(),
         set_spn=MagicMock(),
         set_managed_identity=MagicMock(),

--- a/tests/test_commands/test_auth.py
+++ b/tests/test_commands/test_auth.py
@@ -1044,6 +1044,149 @@ class TestAuth:
         mock_fab_context_instance.reset_context.assert_called_once()
         mock_print.assert_called_once()
 
+    def test_auth_list_no_sessions(self, mock_fab_auth):
+        args = argparse.Namespace(command="auth", output_format=None)
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.get_user_sessions.return_value = []
+
+        with patch(
+            "fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"
+        ) as mock_print:
+            fab_auth.list_accounts(args)
+
+        mock_print.assert_called_once()
+        assert "message" in mock_print.call_args.kwargs
+
+    def test_auth_switch_env_vars_blocks(self, mock_fab_auth):
+        args = argparse.Namespace(
+            command="auth",
+            output_format=None,
+            username=None,
+            tenant=None,
+        )
+        with patch.dict(os.environ, {"FAB_TOKEN": "some-token"}):
+            with pytest.raises(FabricCLIError) as exc_info:
+                fab_auth.switch(args)
+            assert exc_info.value.status_code == fab_constant.ERROR_INVALID_OPERATION
+
+    def test_auth_switch_case_insensitive_username(self, mock_fab_auth, mock_fab_context):
+        args = argparse.Namespace(
+            command="auth",
+            output_format=None,
+            username="ALICE@EXAMPLE.COM",
+            tenant=None,
+        )
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.get_user_sessions.return_value = [
+            {
+                "session_id": "session-a",
+                "account_name": "alice@example.com",
+                "tenant_id": "tenant-a",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            }
+        ]
+        mock_fab_auth_instance.get_active_user_session.return_value = {
+            "session_id": "session-a"
+        }
+
+        with patch(
+            "fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"
+        ):
+            fab_auth.switch(args)
+
+        mock_fab_auth_instance.activate_user_session.assert_called_once_with(
+            "session-a"
+        )
+
+    def test_auth_switch_interactive_prompt_with_three_accounts(
+        self, mock_fab_auth, mock_fab_context
+    ):
+        args = argparse.Namespace(
+            command="auth",
+            output_format=None,
+            username=None,
+            tenant=None,
+        )
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.get_user_sessions.return_value = [
+            {
+                "session_id": "session-a",
+                "account_name": "alice@example.com",
+                "tenant_id": "tenant-a",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            },
+            {
+                "session_id": "session-b",
+                "account_name": "bob@example.com",
+                "tenant_id": "tenant-b",
+                "last_used_at": "2026-04-06T12:00:00Z",
+            },
+            {
+                "session_id": "session-c",
+                "account_name": "carol@example.com",
+                "tenant_id": "tenant-c",
+                "last_used_at": "2026-04-05T12:00:00Z",
+            },
+        ]
+        mock_fab_auth_instance.get_active_user_session.return_value = {
+            "session_id": "session-a"
+        }
+
+        with (
+            patch(
+                "fabric_cli.commands.auth.fab_auth.fab_ui.prompt_select_item",
+                return_value="bob@example.com (tenant-b)",
+            ),
+            patch(
+                "fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"
+            ),
+        ):
+            fab_auth.switch(args)
+
+        mock_fab_auth_instance.activate_user_session.assert_called_once_with(
+            "session-b"
+        )
+
+    def test_auth_switch_cancelled_prompt(self, mock_fab_auth):
+        args = argparse.Namespace(
+            command="auth",
+            output_format=None,
+            username=None,
+            tenant=None,
+        )
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.get_user_sessions.return_value = [
+            {
+                "session_id": "session-a",
+                "account_name": "alice@example.com",
+                "tenant_id": "tenant-a",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            },
+            {
+                "session_id": "session-b",
+                "account_name": "bob@example.com",
+                "tenant_id": "tenant-b",
+                "last_used_at": "2026-04-06T12:00:00Z",
+            },
+            {
+                "session_id": "session-c",
+                "account_name": "carol@example.com",
+                "tenant_id": "tenant-c",
+                "last_used_at": "2026-04-05T12:00:00Z",
+            },
+        ]
+        mock_fab_auth_instance.get_active_user_session.return_value = {
+            "session_id": "session-a"
+        }
+
+        with patch(
+            "fabric_cli.commands.auth.fab_auth.fab_ui.prompt_select_item",
+            return_value=None,
+        ):
+            with pytest.raises(FabricCLIError) as exc_info:
+                fab_auth.switch(args)
+            assert exc_info.value.status_code == fab_constant.ERROR_OPERATION_CANCELLED
+
     def test_init_when_user_cancels_the_prompt(
         self, mock_fab_auth, mock_fab_context, mock_fab_logger_log_warning, capsys
     ):

--- a/tests/test_commands/test_auth.py
+++ b/tests/test_commands/test_auth.py
@@ -28,6 +28,7 @@ def reset_fab_auth_state(monkeypatch, tmp_path):
     auth._auth_info = {}
     auth.app = None
     auth.aad_public_key = None
+    auth._preserve_user_app_during_login = False
 
 
 class TestAuth:
@@ -45,6 +46,7 @@ class TestAuth:
             # Assert
             mock_fab_auth_instance = mock_fab_auth.get("instance")
             mock_fab_auth_instance.prepare_user_login.assert_called_with(None)
+            mock_fab_auth_instance.finish_user_login.assert_called_once()
             assert_get_access_token(mock_fab_auth_instance, interactive_first=True)
             assert result is True
 
@@ -68,6 +70,7 @@ class TestAuth:
             # Assert
             mock_fab_auth_instance = mock_fab_auth.get("instance")
             mock_fab_auth_instance.prepare_user_login.assert_called_with("mock_tenant")
+            mock_fab_auth_instance.finish_user_login.assert_called_once()
             assert_get_access_token(mock_fab_auth_instance, interactive_first=True)
             assert result is True
 
@@ -1069,7 +1072,9 @@ class TestAuth:
                 fab_auth.switch(args)
             assert exc_info.value.status_code == fab_constant.ERROR_INVALID_OPERATION
 
-    def test_auth_switch_case_insensitive_username(self, mock_fab_auth, mock_fab_context):
+    def test_auth_switch_case_insensitive_username(
+        self, mock_fab_auth, mock_fab_context
+    ):
         args = argparse.Namespace(
             command="auth",
             output_format=None,
@@ -1089,9 +1094,7 @@ class TestAuth:
             "session_id": "session-a"
         }
 
-        with patch(
-            "fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"
-        ):
+        with patch("fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"):
             fab_auth.switch(args)
 
         mock_fab_auth_instance.activate_user_session.assert_called_once_with(
@@ -1137,9 +1140,7 @@ class TestAuth:
                 "fabric_cli.commands.auth.fab_auth.fab_ui.prompt_select_item",
                 return_value="bob@example.com (tenant-b)",
             ),
-            patch(
-                "fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"
-            ),
+            patch("fabric_cli.commands.auth.fab_auth.fab_ui.print_output_format"),
         ):
             fab_auth.switch(args)
 
@@ -1238,6 +1239,7 @@ def assert_fab_auth_not_called(mock_fab_auth):
     mock_fab_auth_instance = mock_fab_auth.get("instance")
     mock_fab_auth_instance.set_access_mode.assert_not_called()
     mock_fab_auth_instance.prepare_user_login.assert_not_called()
+    mock_fab_auth_instance.finish_user_login.assert_not_called()
     mock_fab_auth_instance.set_tenant.assert_not_called()
     mock_fab_auth_instance.set_spn.assert_not_called()
     mock_fab_auth_instance.get_access_token.assert_not_called()
@@ -1284,8 +1286,10 @@ def mock_fab_auth():
         remove_user_session=MagicMock(return_value=None),
         activate_user_session=MagicMock(),
         is_user_session_valid=MagicMock(return_value=True),
+        _create_user_app=MagicMock(side_effect=lambda tenant_id: object()),
         set_access_mode=MagicMock(),
         prepare_user_login=MagicMock(),
+        finish_user_login=MagicMock(),
         set_tenant=MagicMock(),
         set_spn=MagicMock(),
         set_managed_identity=MagicMock(),

--- a/tests/test_commands/test_auth.py
+++ b/tests/test_commands/test_auth.py
@@ -45,7 +45,7 @@ class TestAuth:
             # Assert
             mock_fab_auth_instance = mock_fab_auth.get("instance")
             mock_fab_auth_instance.prepare_user_login.assert_called_with(None)
-            assert_get_access_token(mock_fab_auth_instance)
+            assert_get_access_token(mock_fab_auth_instance, interactive_first=True)
             assert result is True
 
             assert_fab_context(mock_fab_context)
@@ -68,7 +68,7 @@ class TestAuth:
             # Assert
             mock_fab_auth_instance = mock_fab_auth.get("instance")
             mock_fab_auth_instance.prepare_user_login.assert_called_with("mock_tenant")
-            assert_get_access_token(mock_fab_auth_instance)
+            assert_get_access_token(mock_fab_auth_instance, interactive_first=True)
             assert result is True
 
             assert_fab_context(mock_fab_context)
@@ -1100,10 +1100,16 @@ def assert_fab_auth_not_called(mock_fab_auth):
     mock_fab_auth_instance.get_access_token.assert_not_called()
 
 
-def assert_get_access_token(mock_fab_auth_instance):
-    mock_fab_auth_instance.get_access_token.assert_any_call(
-        scope=fab_constant.SCOPE_FABRIC_DEFAULT
-    )
+def assert_get_access_token(mock_fab_auth_instance, interactive_first: bool = False):
+    if interactive_first:
+        mock_fab_auth_instance.get_access_token.assert_any_call(
+            scope=fab_constant.SCOPE_FABRIC_DEFAULT,
+            force_interactive=True,
+        )
+    else:
+        mock_fab_auth_instance.get_access_token.assert_any_call(
+            scope=fab_constant.SCOPE_FABRIC_DEFAULT
+        )
     mock_fab_auth_instance.get_access_token.assert_any_call(
         scope=fab_constant.SCOPE_ONELAKE_DEFAULT
     )

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -398,6 +398,31 @@ def test_get_access_token_user_interactive_success():
         set_tenant_spy.assert_called_with(expected_tenant)
 
 
+def test_get_access_token_user_force_interactive_skips_silent_token():
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+
+    with (
+        patch.object(auth, "set_tenant", wraps=auth.set_tenant) as set_tenant_spy,
+        patch.object(auth, "app", wraps=auth.app) as mock_app,
+    ):
+        mock_app.get_accounts.return_value = []
+        mock_app.acquire_token_silent.return_value = {"access_token": "silent_token"}
+        mock_app.acquire_token_interactive.return_value = {
+            "access_token": "interactive_token",
+            "id_token_claims": {"tid": "tenant_id"},
+        }
+
+        token = auth.get_access_token(
+            [con.SCOPE_FABRIC_DEFAULT], force_interactive=True
+        )
+
+        assert token == "interactive_token"
+        mock_app.acquire_token_silent.assert_not_called()
+        mock_app.acquire_token_interactive.assert_called_once()
+        set_tenant_spy.assert_called_with("tenant_id")
+
+
 def test_validate_jwt_token_success():
     # Build a valid JWT token
     # This is a mock token for testing purposes

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -1109,6 +1109,76 @@ def test_set_tenant_for_user_does_not_logout(monkeypatch):
     assert auth.get_tenant_id() == "tenant-b"
 
 
+def test_set_tenant_preserves_app_when_tenant_unchanged():
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user", con.FAB_TENANT_ID: "tenant-a"}
+    sentinel_app = object()
+    auth.app = sentinel_app
+
+    auth.set_tenant("tenant-a")
+
+    assert auth.app is sentinel_app
+
+
+def test_set_tenant_resets_app_when_tenant_changes():
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user", con.FAB_TENANT_ID: "tenant-a"}
+    auth.app = object()
+
+    auth.set_tenant("tenant-b")
+
+    assert auth.app is None
+    assert auth.get_tenant_id() == "tenant-b"
+
+
+def test_sync_active_user_session_preserves_app_when_tenant_unchanged(tmp_path):
+    auth = FabAuth()
+    auth.auth_file = os.path.join(tmp_path, "auth.json")
+    sentinel_app = object()
+    auth.app = sentinel_app
+    auth._auth_info = {
+        con.IDENTITY_TYPE: "user",
+        con.FAB_TENANT_ID: "tenant-a",
+        "active_user_session_id": "session-a",
+        "user_sessions": [
+            {
+                "session_id": "session-a",
+                "account_name": "alice@example.com",
+                "tenant_id": "tenant-a",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            },
+        ],
+    }
+
+    auth._sync_active_user_session()
+
+    assert auth.app is sentinel_app
+
+
+def test_sync_active_user_session_resets_app_when_tenant_changes(tmp_path):
+    auth = FabAuth()
+    auth.auth_file = os.path.join(tmp_path, "auth.json")
+    auth.app = object()
+    auth._auth_info = {
+        con.IDENTITY_TYPE: "user",
+        con.FAB_TENANT_ID: "tenant-a",
+        "active_user_session_id": "session-b",
+        "user_sessions": [
+            {
+                "session_id": "session-b",
+                "account_name": "bob@example.com",
+                "tenant_id": "tenant-b",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            },
+        ],
+    }
+
+    auth._sync_active_user_session()
+
+    assert auth.app is None
+    assert auth.get_tenant_id() == "tenant-b"
+
+
 def test_get_user_sessions_returns_active_first():
     auth = FabAuth()
     auth._auth_info = {
@@ -1163,3 +1233,37 @@ def test_activate_user_session_updates_active_auth_state(tmp_path):
     assert auth.get_tenant_id() == "tenant-b"
     assert auth._auth_info["active_user_session_id"] == "session-b"
     assert auth._auth_info["active_user_account_name"] == "bob@example.com"
+
+
+def test_utc_now_returns_z_suffix():
+    result = FabAuth._utc_now()
+    assert result.endswith("Z")
+    assert "+" not in result
+    # Should be parseable as ISO 8601
+    datetime.datetime.fromisoformat(result.replace("Z", "+00:00"))
+
+
+def test_is_user_session_valid_accepts_shared_app():
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+
+    mock_app = patch.object(auth, "_create_user_app").start()
+    mock_app.return_value = mock_app
+
+    mock_external_app = type("FakeApp", (), {
+        "get_accounts": lambda self, *a, **kw: [{"username": "alice@example.com", "home_account_id": "h1"}],
+        "acquire_token_silent": lambda self, *a, **kw: {"access_token": "tok"},
+    })()
+
+    session = {
+        "session_id": "s1",
+        "account_name": "alice@example.com",
+        "home_account_id": "h1",
+        "tenant_id": "t1",
+    }
+
+    result = auth.is_user_session_valid(session, app=mock_external_app)
+    assert result is True
+    # _create_user_app should NOT have been called since we passed an app
+    mock_app.assert_not_called()
+    patch.stopall()

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -34,6 +34,7 @@ def temp_dir_fixture(monkeypatch, tmp_path):
     auth._auth_info = {}
     auth.app = None
     auth.aad_public_key = None
+    auth._preserve_user_app_during_login = False
     return str(tmp_path)
 
 
@@ -1131,6 +1132,63 @@ def test_set_tenant_resets_app_when_tenant_changes():
     assert auth.get_tenant_id() == "tenant-b"
 
 
+def test_prepare_user_login_preserves_app_until_login_finishes():
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user", con.FAB_TENANT_ID: "tenant-a"}
+    sentinel_app = object()
+
+    with patch.object(auth, "_create_user_app", return_value=sentinel_app):
+        auth.prepare_user_login()
+
+    auth.set_tenant("tenant-b")
+
+    assert auth.app is sentinel_app
+
+    auth.finish_user_login()
+    auth.set_tenant("tenant-c")
+
+    assert auth.app is None
+    assert auth.get_tenant_id() == "tenant-c"
+
+
+def test_get_access_token_during_login_uses_legacy_first_account(monkeypatch):
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+    auth._preserve_user_app_during_login = True
+
+    chosen_accounts = []
+
+    class FakeUserApp:
+        def get_accounts(self):
+            return [
+                {"username": "legacy@example.com", "home_account_id": "legacy"},
+                {"username": "session@example.com", "home_account_id": "session"},
+            ]
+
+        def acquire_token_silent(self, *, scopes, account):
+            chosen_accounts.append(account)
+            return {"access_token": "silent_token"}
+
+    fake_app = FakeUserApp()
+    monkeypatch.setattr(auth, "_get_app", lambda: fake_app)
+
+    matching_account_called = {"value": False}
+
+    def fail_if_called(*args, **kwargs):
+        matching_account_called["value"] = True
+        return None
+
+    monkeypatch.setattr(auth, "_get_matching_account", fail_if_called)
+
+    token = auth.get_access_token([con.SCOPE_FABRIC_DEFAULT])
+
+    assert token == "silent_token"
+    assert matching_account_called["value"] is False
+    assert chosen_accounts == [
+        {"username": "legacy@example.com", "home_account_id": "legacy"}
+    ]
+
+
 def test_sync_active_user_session_preserves_app_when_tenant_unchanged(tmp_path):
     auth = FabAuth()
     auth.auth_file = os.path.join(tmp_path, "auth.json")
@@ -1236,7 +1294,7 @@ def test_activate_user_session_updates_active_auth_state(tmp_path):
 
 
 def test_utc_now_returns_z_suffix():
-    result = FabAuth._utc_now()
+    result = FabAuth()._utc_now()
     assert result.endswith("Z")
     assert "+" not in result
     # Should be parseable as ISO 8601
@@ -1250,10 +1308,16 @@ def test_is_user_session_valid_accepts_shared_app():
     mock_app = patch.object(auth, "_create_user_app").start()
     mock_app.return_value = mock_app
 
-    mock_external_app = type("FakeApp", (), {
-        "get_accounts": lambda self, *a, **kw: [{"username": "alice@example.com", "home_account_id": "h1"}],
-        "acquire_token_silent": lambda self, *a, **kw: {"access_token": "tok"},
-    })()
+    mock_external_app = type(
+        "FakeApp",
+        (),
+        {
+            "get_accounts": lambda self, *a, **kw: [
+                {"username": "alice@example.com", "home_account_id": "h1"}
+            ],
+            "acquire_token_silent": lambda self, *a, **kw: {"access_token": "tok"},
+        },
+    )()
 
     session = {
         "session_id": "s1",

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -28,6 +28,12 @@ def temp_dir_fixture(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "fabric_cli.core.fab_state_config.config_location", lambda: str(tmp_path)
     )
+    auth = FabAuth()
+    auth.auth_file = os.path.join(tmp_path, "auth.json")
+    auth.cache_file = os.path.join(tmp_path, "cache.bin")
+    auth._auth_info = {}
+    auth.app = None
+    auth.aad_public_key = None
     return str(tmp_path)
 
 
@@ -344,7 +350,6 @@ def test_get_access_token_user_silent_success():
         patch.object(auth, "set_tenant", wraps=auth.set_tenant) as set_tenant_spy,
         patch.object(auth, "app", wraps=auth.app) as mock_app,
     ):
-
         mock_app.acquire_token_silent.return_value = {"access_token": expected_token}
         token = auth.get_access_token([con.SCOPE_FABRIC_DEFAULT])
         assert token == expected_token
@@ -359,7 +364,6 @@ def test_get_access_token_user_interactive_error_response_failure():
         patch.object(auth, "set_tenant", wraps=auth.set_tenant) as set_tenant_spy,
         patch.object(auth, "app", wraps=auth.app) as mock_app,
     ):
-
         mock_app.acquire_token_silent.return_value = None
         mock_app.acquire_token_interactive.return_value = {
             "error": "token acquisition failed"
@@ -381,7 +385,6 @@ def test_get_access_token_user_interactive_success():
         patch.object(auth, "set_tenant", wraps=auth.set_tenant) as set_tenant_spy,
         patch.object(auth, "app", wraps=auth.app) as mock_app,
     ):
-
         set_tenant_spy.configure_mock(**{"return_value": None})
 
         mock_app.acquire_token_silent.return_value = None
@@ -824,8 +827,12 @@ def test_get_access_token_token_error(monkeypatch):
     with pytest.raises(FabricCLIError) as exc_info:
         auth.get_access_token(["dummy_scope"])
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
-    assert exc_info.value.message == "Failed to get access token: Something went wrong while trying to acquire a token. Please try to run `fab auth logout` and then `fab auth login` to re-login and acquire new tokens"
+    assert (
+        exc_info.value.message
+        == "Failed to get access token: Something went wrong while trying to acquire a token. Please try to run `fab auth logout` and then `fab auth login` to re-login and acquire new tokens"
+    )
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
+
 
 def test_set_access_mode_success(monkeypatch):
     """Test setting a valid access mode"""
@@ -1064,3 +1071,70 @@ def test_auth_mode_migration(tmp_path):
     assert (
         auth.get_identity_type() == "user"
     ), "get_identity_type returns wrong value after migration"
+
+
+def test_set_tenant_for_user_does_not_logout(monkeypatch):
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user", con.FAB_TENANT_ID: "tenant-a"}
+
+    with patch.object(auth, "logout") as mock_logout:
+        auth.set_tenant("tenant-b")
+
+    mock_logout.assert_not_called()
+    assert auth.get_tenant_id() == "tenant-b"
+
+
+def test_get_user_sessions_returns_active_first():
+    auth = FabAuth()
+    auth._auth_info = {
+        con.IDENTITY_TYPE: "user",
+        "active_user_session_id": "session-b",
+        "user_sessions": [
+            {
+                "session_id": "session-a",
+                "account_name": "alice@example.com",
+                "tenant_id": "tenant-a",
+                "last_used_at": "2026-04-06T12:00:00Z",
+            },
+            {
+                "session_id": "session-b",
+                "account_name": "bob@example.com",
+                "tenant_id": "tenant-b",
+                "last_used_at": "2026-04-05T12:00:00Z",
+            },
+        ],
+    }
+
+    sessions = auth.get_user_sessions()
+    assert sessions[0]["session_id"] == "session-b"
+    assert sessions[1]["session_id"] == "session-a"
+
+
+def test_activate_user_session_updates_active_auth_state(tmp_path):
+    auth = FabAuth()
+    auth.auth_file = os.path.join(tmp_path, "auth.json")
+    auth._auth_info = {
+        con.IDENTITY_TYPE: "user",
+        con.FAB_TENANT_ID: "tenant-a",
+        "active_user_session_id": "session-a",
+        "user_sessions": [
+            {
+                "session_id": "session-a",
+                "account_name": "alice@example.com",
+                "tenant_id": "tenant-a",
+                "last_used_at": "2026-04-06T12:00:00Z",
+            },
+            {
+                "session_id": "session-b",
+                "account_name": "bob@example.com",
+                "tenant_id": "tenant-b",
+                "last_used_at": "2026-04-07T12:00:00Z",
+            },
+        ],
+    }
+
+    auth.activate_user_session("session-b")
+
+    assert auth.get_tenant_id() == "tenant-b"
+    assert auth._auth_info["active_user_session_id"] == "session-b"
+    assert auth._auth_info["active_user_account_name"] == "bob@example.com"


### PR DESCRIPTION
Closes #206

## Summary

- Add `fab auth list` to display all stored user sessions (active, valid, tenant, last used)
- Add `fab auth switch` to switch between stored sessions - direct (`-u`, `-t`) or interactive prompt
- Extend `fab auth logout` with per-session removal (`-u`, `-t`) and bulk clear (`--all`)
- Username matching is case-insensitive across all session commands
- Session switching is blocked with a clear error when env var auth (`FAB_TOKEN`, etc.) is active
- Force interactive re-login on `fab auth login` so new accounts are always stored as distinct sessions
- Fix the Windows WAM login regression by preserving the broker-backed MSAL app for the full multi-scope login flow and using the legacy account lookup while OneLake and Azure tokens are warmed up

## Use case

Consultants and developers working across multiple Fabric tenants (e.g. Client A production, Client B dev, internal corporate) currently need a full logout/login cycle to switch context. This PR lets them authenticate once per account and switch instantly:

```bash
fab auth login          # log in as alice@clientA.com
fab auth login          # log in as bob@clientB.com

fab auth list           # see both sessions
fab auth switch -u alice@clientA.com   # switch directly
fab auth switch         # toggle (2 accounts) or prompt (3+)
fab auth logout -u bob@clientB.com     # remove one session
```

## Verification

- `uv run pytest tests/test_core/test_fab_auth.py tests/test_commands/test_auth.py`

## Test plan

- [ ] `fab auth login` with interactive browser - stores session correctly
- [ ] `fab auth login` with a second account - both sessions visible in `fab auth list`
- [ ] `fab auth switch -u <name>` - switches directly (case-insensitive)
- [ ] `fab auth switch` with 2 sessions - auto-toggles
- [ ] `fab auth switch` with 3+ sessions - shows interactive prompt
- [ ] `fab auth switch` with `FAB_TOKEN` set - returns clear error
- [ ] `fab auth logout -u <name>` - removes only that session
- [ ] `fab auth logout --all` - clears everything
- [ ] `fab auth status` - reflects the active session
- [ ] SPN and managed identity flows remain unaffected
- [x] Unit tests pass