### PR TITLE
fix: remove hardcoded "Created by fab" description from mkdir and imp…

### DIFF
--- a/.changes/unreleased/fixed-20260415-120000.yaml
+++ b/.changes/unreleased/fixed-20260415-120000.yaml
@@ -1,0 +1,6 @@
+kind: fixed
+body: Remove hardcoded "Created by fab" and "Imported from fab" descriptions from mkdir and import commands
+time: 2026-04-15T12:00:00.000000000Z
+custom:
+    Author: HasanAboShally
+    AuthorLink: https://github.com/HasanAboShally

--- a/src/fabric_cli/commands/fs/impor/fab_fs_import_item.py
+++ b/src/fabric_cli/commands/fs/impor/fab_fs_import_item.py
@@ -103,7 +103,6 @@ def _import_create_environment_item(
 
     item_payload: dict = {
         "type": str(item.item_type),
-        "description": "Imported from fab",
         "displayName": item.short_name,
         "folderId": item.folder_id,
     }

--- a/src/fabric_cli/commands/fs/impor/fab_fs_import_item.py
+++ b/src/fabric_cli/commands/fs/impor/fab_fs_import_item.py
@@ -60,12 +60,10 @@ def import_single_item(item: Item, args: Namespace) -> None:
                 else:
                     _import_update_item(args, payload)
 
-                utils_ui.print_output_format(
-                    args, message=f"'{item.name}' imported")
+                utils_ui.print_output_format(args, message=f"'{item.name}' imported")
         else:
             # Create
-            utils_ui.print_grey(
-                f"Importing '{_input_path}' → '{item.path}'...")
+            utils_ui.print_grey(f"Importing '{_input_path}' → '{item.path}'...")
 
             # Environment item type, not supporting definition yet
             if item.item_type == ItemType.ENVIRONMENT:
@@ -74,8 +72,7 @@ def import_single_item(item: Item, args: Namespace) -> None:
                 response = _import_create_item(args, payload)
 
             if response.status_code in (200, 201):
-                utils_ui.print_output_format(
-                    args, message=f"'{item.name}' imported")
+                utils_ui.print_output_format(args, message=f"'{item.name}' imported")
                 data = json.loads(response.text)
                 item._id = data["id"]
 
@@ -106,6 +103,9 @@ def _import_create_environment_item(
         "displayName": item.short_name,
         "folderId": item.folder_id,
     }
+    description = getattr(args, "description", None)
+    if description is not None:
+        item_payload["description"] = description
     item_payload_str = json.dumps(item_payload)
 
     # Create the item

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_connection.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_connection.py
@@ -110,7 +110,6 @@ def exec(connection: VirtualWorkspaceItem, args: Namespace) -> None:
 
     # Base payload
     payload = {
-        "description": "Created by fab",
         "displayName": connection.short_name,
         "connectivityType": connectivityType,
     }

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_connection.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_connection.py
@@ -113,6 +113,8 @@ def exec(connection: VirtualWorkspaceItem, args: Namespace) -> None:
         "displayName": connection.short_name,
         "connectivityType": connectivityType,
     }
+    if params.get("description") is not None:
+        payload["description"] = params.get("description")
     if gateway_id:
         payload["gatewayId"] = gateway_id
 
@@ -125,7 +127,9 @@ def exec(connection: VirtualWorkspaceItem, args: Namespace) -> None:
     response = connection_api.create_connection(args, payload=json_payload)
     if response.status_code in (200, 201):
         data = json.loads(response.text)
-        utils_ui.print_output_format(args, message=f"'{connection.name}' created", data=data, show_headers=True)
+        utils_ui.print_output_format(
+            args, message=f"'{connection.name}' created", data=data, show_headers=True
+        )
 
         connection._id = data["id"]
 

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_folder.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_folder.py
@@ -26,7 +26,6 @@ def exec(folder: Folder, args: Namespace) -> str | None:
     utils_ui.print_grey(f"Creating a new Folder...")
 
     payload = {
-        "description": "Created by fab",
         "displayName": foldername,
     }
     if parent_folder_id:

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_gateway.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_gateway.py
@@ -84,7 +84,6 @@ def exec(gateway: VirtualWorkspaceItem, args: Namespace) -> None:
     }
 
     payload = {
-        # "description": "Created by fab",
         "displayName": gateway.short_name,
         "capacityId": params.get("capacityid"),
         "inactivityMinutesBeforeSleep": params.get("inactivityminutesbeforesleep", 30),
@@ -96,7 +95,9 @@ def exec(gateway: VirtualWorkspaceItem, args: Namespace) -> None:
     response = gateway_api.create_gateway(args, payload=json.dumps(payload))
     if response.status_code in (200, 201):
         data = json.loads(response.text)
-        utils_ui.print_output_format(args, message=f"'{gateway.name}' created", data=data, show_headers=True)
+        utils_ui.print_output_format(
+            args, message=f"'{gateway.name}' created", data=data, show_headers=True
+        )
         gateway._id = data["id"]
 
         # Add to mem_store

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_item.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_item.py
@@ -78,7 +78,6 @@ def exec(item: Item, args: Namespace) -> str | None:
     utils.remove_keys_from_dict(params, ["displayname", "type"])
 
     payload = {
-        "description": "Created by fab",
         "displayName": item_name,
         "type": str(item_type),
         "folderId": item.folder_id,

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_managedprivateendpoint.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_managedprivateendpoint.py
@@ -42,13 +42,12 @@ def exec(managed_private_endpoint: VirtualItem, args: Namespace) -> None:
         "name": managed_private_endpoint_name,
         "targetPrivateLinkResourceId": params.get("targetprivatelinkresourceid"),
         "targetSubresourceType": params.get("targetsubresourcetype"),
-        "requestMessage": "Created by fab",
     }
 
     args.ws_id = managed_private_endpoint.workspace.id
 
     response = managed_private_endpoint_api.create_managed_private_endpoint(
-        args, payload= json.dumps(payload)
+        args, payload=json.dumps(payload)
     )
     if response.status_code in (200, 201):
         data = json.loads(response.text)
@@ -126,7 +125,7 @@ def exec(managed_private_endpoint: VirtualItem, args: Namespace) -> None:
                         _args
                     )
                     if response.status_code == 200:
-                        result_message=f"'{managed_private_endpoint.name}' approved"
+                        result_message = f"'{managed_private_endpoint.name}' approved"
                     else:
                         raise Exception("Approval failed")
             except Exception:
@@ -135,4 +134,6 @@ def exec(managed_private_endpoint: VirtualItem, args: Namespace) -> None:
                     fab_constant.ERROR_OPERATION_FAILED,
                 )
 
-    utils_ui.print_output_format(args, message=result_message, data=data, show_headers=True)
+    utils_ui.print_output_format(
+        args, message=result_message, data=data, show_headers=True
+    )

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_managedprivateendpoint.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_managedprivateendpoint.py
@@ -49,6 +49,12 @@ def exec(managed_private_endpoint: VirtualItem, args: Namespace) -> None:
     response = managed_private_endpoint_api.create_managed_private_endpoint(
         args, payload=json.dumps(payload)
     )
+    if response.status_code not in (200, 201):
+        raise FabricCLIError(
+            "Failed to create Managed Private Endpoint",
+            fab_constant.ERROR_OPERATION_FAILED,
+        )
+
     if response.status_code in (200, 201):
         data = json.loads(response.text)
         managed_private_endpoint._id = data["id"]

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_workspace.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_workspace.py
@@ -68,7 +68,6 @@ def exec(workspace: Workspace, args: Namespace) -> None:
     utils.remove_keys_from_dict(args.params, ["displayName"])
 
     payload = {
-        "description": "Created by fab",
         "displayName": workspace.short_name,
     }
     payload.update(args.params)

--- a/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_workspace.py
+++ b/src/fabric_cli/commands/fs/mkdir/fab_fs_mkdir_workspace.py
@@ -65,7 +65,7 @@ def exec(workspace: Workspace, args: Namespace) -> None:
     utils_ui.print_grey("Creating a new Workspace...")
 
     # Remove all unwanted keys from the params
-    utils.remove_keys_from_dict(args.params, ["displayName"])
+    utils.remove_keys_from_dict(args.params, ["displayname"])
 
     payload = {
         "displayName": workspace.short_name,
@@ -80,5 +80,6 @@ def exec(workspace: Workspace, args: Namespace) -> None:
         # Add to mem_store
         utils_mem_store.upsert_workspace_to_cache(workspace)
 
-        utils_ui.print_output_format(args, message=f"'{workspace.name}' created", data=data, show_headers=True)
-
+        utils_ui.print_output_format(
+            args, message=f"'{workspace.name}' created", data=data, show_headers=True
+        )

--- a/src/fabric_cli/utils/fab_cmd_import_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_import_utils.py
@@ -28,7 +28,6 @@ def get_payload_for_item_type(
         definition = _build_definition(path, input_format)
         return {
             "type": str(item.item_type),
-            "description": "Imported from fab",
             "folderId": item.folder_id,
             "displayName": item.short_name,
             "definition": definition,

--- a/tests/test_core/test_fab_hiearchy.py
+++ b/tests/test_core/test_fab_hiearchy.py
@@ -408,7 +408,6 @@ def test_get_item_payloads_success():
 
     _expected_payload = {
         "type": "Notebook",
-        "description": "Imported from fab",
         "displayName": "item_name",
         "folderId": None,
         "definition": {"format": "ipynb", "parts": _base_payload["parts"]},
@@ -429,7 +428,6 @@ def test_get_item_payloads_success():
 
     _expected_payload = {
         "type": "SparkJobDefinition",
-        "description": "Imported from fab",
         "displayName": "item_name",
         "folderId": None,
         "definition": {
@@ -445,7 +443,6 @@ def test_get_item_payloads_success():
 
     _expected_payload = {
         "type": "SparkJobDefinition",
-        "description": "Imported from fab",
         "displayName": "item_name",
         "folderId": None,
         "definition": {
@@ -469,7 +466,6 @@ def test_get_item_payloads_success():
 
     _expected_payload = {
         "type": "Eventhouse",
-        "description": "Imported from fab",
         "displayName": "item_name",
         "folderId": None,
         "definition": {"parts": _base_payload["parts"]},
@@ -490,7 +486,6 @@ def test_get_item_payloads_success():
 
     _expected_payload = {
         "type": "Report",
-        "description": "Imported from fab",
         "displayName": "item_name",
         "folderId": None,
         "definition": {"parts": _base_payload["parts"]},
@@ -506,7 +501,6 @@ def test_get_item_payloads_success():
 
     _expected_payload_without_format = {
         "type": "SemanticModel",
-        "description": "Imported from fab",
         "displayName": "item_name",
         "folderId": None,
         "definition": {"parts": _base_payload["parts"]},
@@ -518,7 +512,6 @@ def test_get_item_payloads_success():
 
     _expected_payload_with_format = {
         "type": "SemanticModel",
-        "description": "Imported from fab",
         "displayName": "item_name",
         "folderId": None,
         "definition": {

--- a/tests/test_core/test_fab_hiearchy.py
+++ b/tests/test_core/test_fab_hiearchy.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from unittest.mock import patch
+import json
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -137,8 +139,7 @@ def test_create_virtual_item_success():
     workspace = Workspace(
         name="My workspace", id="workspace_id", parent=tenant, type="Personal"
     )
-    container = VirtualItemContainer(
-        name=".sparkpools", id=None, parent=workspace)
+    container = VirtualItemContainer(name=".sparkpools", id=None, parent=workspace)
     item = VirtualItem(
         name="mySparkPool",
         id="virtual_item_id",
@@ -362,8 +363,7 @@ def test_create_virtual_item_container_success():
     workspace = Workspace(
         name="My workspace", id="workspace_id", parent=tenant, type="Personal"
     )
-    container = VirtualItemContainer(
-        name=".sparkpools", id=None, parent=workspace)
+    container = VirtualItemContainer(name=".sparkpools", id=None, parent=workspace)
     assert container.parent == workspace
     assert container.tenant.id == "0000"
     assert container.tenant.name == "tenant_name.Tenant"
@@ -414,9 +414,13 @@ def test_get_item_payloads_success():
     }
 
     # Check that the payload is correct
-    with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
-        assert get_payload_for_item_type(
-            "dummy", notebook, "ipynb") == _expected_payload
+    with patch(
+        "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+        side_effect=_mock_build,
+    ):
+        assert (
+            get_payload_for_item_type("dummy", notebook, "ipynb") == _expected_payload
+        )
 
     # Test Spark Job Definition
     spark_job_def = Item(
@@ -437,9 +441,14 @@ def test_get_item_payloads_success():
     }
 
     # Check that the payload is correct
-    with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
-        assert get_payload_for_item_type("dummy",
-                                         spark_job_def, "SparkJobDefinitionV2") == _expected_payload
+    with patch(
+        "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+        side_effect=_mock_build,
+    ):
+        assert (
+            get_payload_for_item_type("dummy", spark_job_def, "SparkJobDefinitionV2")
+            == _expected_payload
+        )
 
     _expected_payload = {
         "type": "SparkJobDefinition",
@@ -452,9 +461,14 @@ def test_get_item_payloads_success():
     }
 
     # Check that the payload is correct
-    with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
-        assert get_payload_for_item_type(
-            "dummy", spark_job_def, "SparkJobDefinitionV1") == _expected_payload
+    with patch(
+        "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+        side_effect=_mock_build,
+    ):
+        assert (
+            get_payload_for_item_type("dummy", spark_job_def, "SparkJobDefinitionV1")
+            == _expected_payload
+        )
 
     # Test EventHouse
     event_house = Item(
@@ -472,9 +486,11 @@ def test_get_item_payloads_success():
     }
 
     # Check that the payload is correct
-    with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
-        assert get_payload_for_item_type(
-            "dummy", event_house) == _expected_payload
+    with patch(
+        "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+        side_effect=_mock_build,
+    ):
+        assert get_payload_for_item_type("dummy", event_house) == _expected_payload
 
     # Test Report
     report = Item(
@@ -506,9 +522,14 @@ def test_get_item_payloads_success():
         "definition": {"parts": _base_payload["parts"]},
     }
 
-    with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
-        assert get_payload_for_item_type("dummy",
-                                         smenticModel) == _expected_payload_without_format
+    with patch(
+        "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+        side_effect=_mock_build,
+    ):
+        assert (
+            get_payload_for_item_type("dummy", smenticModel)
+            == _expected_payload_without_format
+        )
 
     _expected_payload_with_format = {
         "type": "SemanticModel",
@@ -520,14 +541,20 @@ def test_get_item_payloads_success():
         },
     }
 
-    with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
+    with patch(
+        "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+        side_effect=_mock_build,
+    ):
         assert (
             get_payload_for_item_type("dummy", smenticModel, "TMDL")
             == _expected_payload_with_format
         )
 
     # Check that the payload is correct
-    with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
+    with patch(
+        "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+        side_effect=_mock_build,
+    ):
         assert get_payload_for_item_type("dummy", report) == _expected_payload
 
 
@@ -540,8 +567,7 @@ def _make_item(item_type: str, parent=None) -> Item:
     """Helper to create an Item with minimal boilerplate."""
     if parent is None:
         tenant = Tenant(name="t", id="tid")
-        parent = Workspace(name="ws", id="wsid",
-                           parent=tenant, type="Workspace")
+        parent = Workspace(name="ws", id="wsid", parent=tenant, type="Workspace")
     return Item(name="item", id="iid", parent=parent, item_type=item_type)
 
 
@@ -575,7 +601,10 @@ class TestBuildPayload:
         def _mock_build(path, resolved_format=""):
             return {"parts": {"key": "value"}}
 
-        with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
+        with patch(
+            "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+            side_effect=_mock_build,
+        ):
             payload = get_payload_for_item_type("dummy", item)
         assert payload["type"] == "Lakehouse"
         assert payload["displayName"] == "item"
@@ -588,7 +617,10 @@ class TestBuildPayload:
         def _mock_build(path, resolved_format=""):
             return {"parts": {"key": "value"}}
 
-        with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
+        with patch(
+            "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+            side_effect=_mock_build,
+        ):
             payload = get_payload_for_item_type("dummy", item)
         assert payload["definition"] == {"parts": {"key": "value"}}
 
@@ -607,7 +639,10 @@ class TestBuildPayload:
                 result["format"] = resolved_format
             return result
 
-        with patch("fabric_cli.utils.fab_cmd_import_utils._build_definition", side_effect=_mock_build):
+        with patch(
+            "fabric_cli.utils.fab_cmd_import_utils._build_definition",
+            side_effect=_mock_build,
+        ):
             payload = get_payload_for_item_type("dummy", item, "ipynb")
         assert payload["folderId"] == "folder123"
         assert payload["definition"]["format"] == "ipynb"
@@ -668,3 +703,119 @@ def test_create_subfolder_success():
         == "/workspace_name.Workspace/folder_name.Folder/subfolder_name.Folder"
     )
     assert subfolder.check_command_support(Command.FS_LS)
+
+
+# -------------------------------------------------------------------
+# Tests for workspace mkdir payload — no hardcoded description
+# -------------------------------------------------------------------
+
+
+class TestMkdirWorkspacePayload:
+    """Validate that workspace creation payloads do not include description by default."""
+
+    def _make_workspace(self, name: str = "test_ws", ws_id: str = None) -> Workspace:
+        tenant = Tenant(name="tenant_name", id="0000")
+        return Workspace(name=name, id=ws_id, parent=tenant, type="Workspace")
+
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.workspace_api")
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.utils_mem_store")
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.utils_ui")
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.fab_state_config")
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.utils")
+    def test_workspace_payload_no_description_by_default_success(
+        self, mock_utils, mock_config, mock_ui, mock_mem_store, mock_ws_api
+    ):
+        """Workspace creation payload should not include 'description' unless user provides one."""
+        from fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace import exec
+
+        workspace = self._make_workspace()
+        mock_config.get_config.return_value = "capacity-id-123"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.text = json.dumps({"id": "new-ws-id", "displayName": "test_ws"})
+        mock_ws_api.create_workspace.return_value = mock_response
+
+        args = Namespace(params={"capacityId": "capacity-id-123"}, output="text")
+        exec(workspace, args)
+
+        # Verify the payload sent to create_workspace
+        call_args = mock_ws_api.create_workspace.call_args
+        sent_payload = json.loads(call_args[0][1])
+        assert "description" not in sent_payload
+        assert sent_payload["displayName"] == "test_ws"
+
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.workspace_api")
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.utils_mem_store")
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.utils_ui")
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.fab_state_config")
+    @patch("fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace.utils")
+    def test_workspace_payload_includes_user_description_success(
+        self, mock_utils, mock_config, mock_ui, mock_mem_store, mock_ws_api
+    ):
+        """When user provides description via params, it should be included in the payload."""
+        from fabric_cli.commands.fs.mkdir.fab_fs_mkdir_workspace import exec
+
+        workspace = self._make_workspace()
+        mock_config.get_config.return_value = "capacity-id-123"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.text = json.dumps({"id": "new-ws-id", "displayName": "test_ws"})
+        mock_ws_api.create_workspace.return_value = mock_response
+
+        args = Namespace(
+            params={
+                "capacityId": "capacity-id-123",
+                "description": "My custom workspace",
+            },
+            output="text",
+        )
+        exec(workspace, args)
+
+        # Verify user-provided description is included
+        call_args = mock_ws_api.create_workspace.call_args
+        sent_payload = json.loads(call_args[0][1])
+        assert sent_payload["description"] == "My custom workspace"
+        assert sent_payload["displayName"] == "test_ws"
+
+
+# -------------------------------------------------------------------
+# Tests for import create environment item — no hardcoded description
+# -------------------------------------------------------------------
+
+
+class TestImportCreateEnvironmentItemPayload:
+    """Validate that _import_create_environment_item payload has no hardcoded description."""
+
+    @patch("fabric_cli.commands.fs.impor.fab_fs_import_item.utils_import")
+    @patch("fabric_cli.commands.fs.impor.fab_fs_import_item.item_api")
+    def test_environment_import_payload_no_description_success(
+        self, mock_item_api, mock_utils_import
+    ):
+        """Environment import create payload should not include 'description'."""
+        from fabric_cli.commands.fs.impor.fab_fs_import_item import (
+            _import_create_environment_item,
+        )
+
+        tenant = Tenant(name="t", id="tid")
+        ws = Workspace(name="ws", id="wsid", parent=tenant, type="Workspace")
+        item = Item(name="myenv", id=None, parent=ws, item_type="Environment")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.text = json.dumps({"id": "env-id-123"})
+        mock_item_api.create_item.return_value = mock_response
+
+        args = Namespace(ws_id="wsid")
+        payload = {"parts": {}}
+
+        _import_create_environment_item(item, args, payload)
+
+        # Verify the payload sent to create_item
+        call_args = mock_item_api.create_item.call_args
+        sent_payload = json.loads(call_args[1]["payload"])
+        assert "description" not in sent_payload
+        assert sent_payload["type"] == "Environment"
+        assert sent_payload["displayName"] == "myenv"
+        assert sent_payload["folderId"] is None

--- a/tests/test_core/test_fab_hiearchy.py
+++ b/tests/test_core/test_fab_hiearchy.py
@@ -739,7 +739,7 @@ class TestMkdirWorkspacePayload:
         mock_response.text = json.dumps({"id": "new-ws-id", "displayName": "test_ws"})
         mock_ws_api.create_workspace.return_value = mock_response
 
-        args = Namespace(params={"capacityId": "capacity-id-123"}, output="text")
+        args = Namespace(params={"capacityid": "capacity-id-123"}, output="text")
         exec(workspace, args)
 
         # Verify the payload sent to create_workspace
@@ -769,7 +769,7 @@ class TestMkdirWorkspacePayload:
 
         args = Namespace(
             params={
-                "capacityId": "capacity-id-123",
+                "capacityid": "capacity-id-123",
                 "description": "My custom workspace",
             },
             output="text",

--- a/tests/test_core/test_fab_hiearchy.py
+++ b/tests/test_core/test_fab_hiearchy.py
@@ -3,6 +3,7 @@
 
 import json
 from argparse import Namespace
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -713,7 +714,9 @@ def test_create_subfolder_success():
 class TestMkdirWorkspacePayload:
     """Validate that workspace creation payloads do not include description by default."""
 
-    def _make_workspace(self, name: str = "test_ws", ws_id: str = None) -> Workspace:
+    def _make_workspace(
+        self, name: str = "test_ws", ws_id: Optional[str] = None
+    ) -> Workspace:
         tenant = Tenant(name="tenant_name", id="0000")
         return Workspace(name=name, id=ws_id, parent=tenant, type="Workspace")
 

--- a/tests/test_utils/test_fab_cmd_mkdir_utils.py
+++ b/tests/test_utils/test_fab_cmd_mkdir_utils.py
@@ -19,7 +19,6 @@ def test_fabric_data_pipelines_workspace_identity_no_params_success():
     """Test FabricDataPipelines with WorkspaceIdentity credential type when no parameters are required."""
     # Arrange
     payload = {
-        "description": "Created by fab",
         "displayName": "test-connection",
         "connectivityType": "ShareableCloud"
     }
@@ -63,7 +62,6 @@ def test_connection_with_required_params_missing_failure():
     """Test that connection creation fails when required parameters are missing."""
     # Arrange
     payload = {
-        "description": "Created by fab",
         "displayName": "test-connection",
         "connectivityType": "ShareableCloud"
     }
@@ -107,7 +105,6 @@ def test_workspace_identity_with_unsupported_params_ignored_success():
     """Test that WorkspaceIdentity ignores unsupported credential parameters with warning."""
     # Arrange
     payload = {
-        "description": "Created by fab",
         "displayName": "test-connection",
         "connectivityType": "ShareableCloud"
     }


### PR DESCRIPTION
# 📥 Pull Request

## ✨ Description of new changes

- **Summary**: Remove the hardcoded `"description"` field from API payloads in `mkdir` and `import` commands. Resolves #213.
- **Context**: When creating items, workspaces, folders, or connections via `mkdir`, the CLI hardcodes `"description": "Created by fab"`. Similarly, `import` hardcodes `"Imported from fab"`. Users have no way to override or opt out of this, and downstream services may propagate the description to child objects, causing unexpected metadata pollution. Resources are now created without a default description unless the user explicitly provides one via params.
- **Dependencies**: None.