### PR TITLE
fix: Add find command to help text and documentaion

### DIFF
--- a/.changes/unreleased/find-docs.md
+++ b/.changes/unreleased/find-docs.md
@@ -1,0 +1,4 @@
+kind: docs
+body: Add find command to help text and docs navigation, update references to OneLake catalog
+custom:
+  Author: nadavs123

--- a/.changes/unreleased/find-docs.md
+++ b/.changes/unreleased/find-docs.md
@@ -1,4 +1,0 @@
-kind: docs
-body: Add find command to help text and docs navigation, update references to OneLake catalog
-custom:
-  Author: nadavs123

--- a/.changes/v1.6.0.md
+++ b/.changes/v1.6.0.md
@@ -7,7 +7,7 @@
 
 ### ✨ New Functionality
 
-* Add new `fab find` command for searching the Fabric catalog across workspaces by [nschachter](https://github.com/nschachter)
+* Add new `fab find` command for searching the OneLake catalog across workspaces by [nschachter](https://github.com/nschachter)
 * Promote VariableLibrary from portal-only to full API support, enabling `create`, `get`, `set`, `rm`, `ls`, `export`, `import`, `cp`, and `mv` commands via the Variable Library REST APIs by [itsnotaboutthecell](https://github.com/itsnotaboutthecell)
 * adds hard flag to rm command (permanent delete) by [v-alexmoraru](https://github.com/v-alexmoraru)
 * supports lakehouse import & export by [v-alexmoraru](https://github.com/v-alexmoraru)

--- a/docs/commands/find.md
+++ b/docs/commands/find.md
@@ -1,6 +1,6 @@
 # `find` Command
 
-Search the Fabric catalog for items across all workspaces.
+Search the OneLake catalog for items across all workspaces.
 
 **Usage:**
 
@@ -14,6 +14,12 @@ fab find <query> [-P <params>] [-l] [-q <query>]
 - `-P, --params`: Filter parameters in `key=value` or `key!=value` format. Use brackets for multiple values: `type=[Lakehouse,Notebook]`. Use `!=` to exclude: `type!=Dashboard`.
 - `-l, --long`: Show detailed table with IDs (name, id, type, workspace, workspace_id, description). Optional.
 - `-q, --query`: JMESPath query to filter results client-side. Optional.
+
+**Supported filter parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `type`    | Filter by item type. Supports `eq` (default) and `ne` (`!=`) operators. |
 
 **Examples:**
 
@@ -43,13 +49,7 @@ fab find 'data' -q "[].{name: name, workspace: workspace}"
 **Behavior:**
 
 - In interactive mode (`fab` shell), results are paged 50 at a time with "Press Enter to continue..." prompts.
-- In command-line mode (`fab find ...`), all results are fetched in a single pass (up to 1000 per API call).
+- In command-line mode (`fab find ...`), all results are fetched by paginating through the full result set.
 - Type names are case-insensitive. `type=lakehouse` matches `Lakehouse`.
 - The `-q` JMESPath filter is applied client-side after results are returned from the API.
-
-**Supported filter parameters:**
-
-| Parameter | Description |
-|-----------|-------------|
-| `type`    | Filter by item type. Supports `eq` (default) and `ne` (`!=`) operators. |
 

--- a/docs/commands/find.md
+++ b/docs/commands/find.md
@@ -21,6 +21,12 @@ fab find <query> [-P <params>] [-l] [-q <query>]
 |-----------|-------------|
 | `type`    | Filter by item type. Supports `eq` (default) and `ne` (`!=`) operators. |
 
+??? note "Supported type names"
+
+    `AnomalyDetector`, `ApacheAirflowJob`, `CopyJob`, `CosmosDBDatabase`, `Dataflow`, `Datamart`, `DataPipeline`, `DigitalTwinBuilder`, `DigitalTwinBuilderFlow`, `Environment`, `Eventhouse`, `EventSchemaSet`, `Eventstream`, `GraphModel`, `GraphQLApi`, `GraphQuerySet`, `KQLDashboard`, `KQLDatabase`, `KQLQueryset`, `Lakehouse`, `Map`, `MirroredAzureDatabricksCatalog`, `MirroredDatabase`, `MirroredWarehouse`, `MLExperiment`, `MLModel`, `MountedDataFactory`, `Notebook`, `Ontology`, `OperationsAgent`, `PaginatedReport`, `Reflex`, `Report`, `SemanticModel`, `SnowflakeDatabase`, `SparkJobDefinition`, `SQLDatabase`, `SQLEndpoint`, `UserDataFunction`, `VariableLibrary`, `Warehouse`, `WarehouseSnapshot`
+
+    Type names are case-insensitive. `Dashboard` is not supported by the Catalog Search API.
+
 **Examples:**
 
 ```
@@ -50,6 +56,5 @@ fab find 'data' -q "[].{name: name, workspace: workspace}"
 
 - In interactive mode (`fab` shell), results are paged 50 at a time with "Press Enter to continue..." prompts.
 - In command-line mode (`fab find ...`), all results are fetched by paginating through the full result set.
-- Type names are case-insensitive. `type=lakehouse` matches `Lakehouse`.
 - The `-q` JMESPath filter is applied client-side after results are returned from the API.
 

--- a/docs/commands/find.md
+++ b/docs/commands/find.md
@@ -19,7 +19,7 @@ fab find <query> [-P <params>] [-l] [-q <query>]
 
 | Parameter | Description |
 |-----------|-------------|
-| `type`    | Filter by item type. Supports `eq` (default) and `ne` (`!=`) operators. |
+| `type`    | Filter by item type. Supports `eq` (`=`, default) and `ne` (`!=`) operators. |
 
 ??? note "Supported type names"
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,7 +15,7 @@ hide:
 
 ### ✨ New Functionality
 
-* Add new `fab find` command for searching the Fabric catalog across workspaces by [nschachter](https://github.com/nschachter)
+* Add new `fab find` command for searching the OneLake catalog across workspaces by [nschachter](https://github.com/nschachter)
 * Promote VariableLibrary from portal-only to full API support, enabling create, get, set, rm, ls, export, import, cp, and mv commands via the Variable Library REST APIs by [itsnotaboutthecell](https://github.com/itsnotaboutthecell)
 * adds hard flag to rm command (permanent delete) by [v-alexmoraru](https://github.com/v-alexmoraru)
 * supports lakehouse import & export by [v-alexmoraru](https://github.com/v-alexmoraru)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
               - desc: commands/desc/index.md
               - export: commands/fs/export.md
               - exists: commands/fs/exists.md
+              - find: commands/find.md
               - get: commands/fs/get.md
               - import: commands/fs/import.md
               - jobs: commands/jobs/index.md

--- a/src/fabric_cli/client/fab_api_catalog.py
+++ b/src/fabric_cli/client/fab_api_catalog.py
@@ -14,7 +14,7 @@ from fabric_cli.client.fab_api_types import ApiResponse
 
 
 def search(args: Namespace, payload: dict) -> ApiResponse:
-    """Search the Fabric catalog for items.
+    """Search the OneLake catalog for items.
 
     https://learn.microsoft.com/en-us/rest/api/fabric/core/catalog/search
 

--- a/src/fabric_cli/commands/find/fab_find.py
+++ b/src/fabric_cli/commands/find/fab_find.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Find command for searching the Fabric catalog."""
+"""Find command for searching the OneLake catalog."""
 
 import json
 import os
@@ -37,7 +37,7 @@ UNSUPPORTED_ITEM_TYPES = _TYPE_CONFIG["unsupported"]
 @handle_exceptions()
 @set_command_context()
 def find_command(args: Namespace) -> None:
-    """Search the Fabric catalog for items."""
+    """Search the OneLake catalog for items."""
     if args.query:
         args.query = utils.process_nargs(args.query)
 

--- a/src/fabric_cli/parsers/fab_find_parser.py
+++ b/src/fabric_cli/parsers/fab_find_parser.py
@@ -10,7 +10,7 @@ from fabric_cli.utils import fab_error_parser as utils_error_parser
 from fabric_cli.utils import fab_ui as utils_ui
 
 
-COMMAND_FIND_DESCRIPTION = "Search the Fabric catalog for items."
+COMMAND_FIND_DESCRIPTION = "Search the OneLake catalog for items."
 
 commands = {
     "Description": {

--- a/src/fabric_cli/utils/fab_commands.py
+++ b/src/fabric_cli/utils/fab_commands.py
@@ -11,6 +11,7 @@ COMMANDS = {
         get_os_specific_command("cp"): "Copy an item or file to a destination.",
         "export": "Export an item.",
         "exists": "Check if a workspace, item, or file exists.",
+        "find": "Search the OneLake catalog for items.",
         "get": "Get workspace or item properties.",
         "import": "Import an item to create or update it.",
         get_os_specific_command("ls"): "List workspaces, items, and files.",


### PR DESCRIPTION
 ### Changes
 
 - **Help text**: Add `find` to Core Commands in `fab --help`
 - **Docs nav**: Add `find` to mkdocs.yml navigation
 - **OneLake catalog**: Update all references from 'Fabric catalog' to 'OneLake catalog'
 - **find.md**: Fix command-line pagination description, move supported filters before examples, add collapsible list of supported type names