### PR TITLE
fix: Fix table separator wrapping and reduce interactive page size

### DIFF
--- a/docs/commands/find.md
+++ b/docs/commands/find.md
@@ -54,7 +54,7 @@ fab find 'data' -q "[].{name: name, workspace: workspace}"
 
 **Behavior:**
 
-- In interactive mode (`fab` shell), results are paged 50 at a time with "Press Enter to continue..." prompts.
+- In interactive mode (`fab` shell), results are paged 30 at a time with "Press Enter to continue..." prompts.
 - In command-line mode (`fab find ...`), all results are fetched by paginating through the full result set.
 - The `-q` JMESPath filter is applied client-side after results are returned from the API.
 

--- a/src/fabric_cli/commands/find/fab_find.py
+++ b/src/fabric_cli/commands/find/fab_find.py
@@ -157,7 +157,7 @@ def _find_commandline(args: Namespace, payload: dict[str, Any]) -> None:
 def _build_search_payload(args: Namespace, is_interactive: bool) -> dict[str, Any]:
     """Build the search request payload from command arguments."""
     request: dict[str, Any] = {"search": args.search_text}
-    request["pageSize"] = 50 if is_interactive else 1000
+    request["pageSize"] = 30 if is_interactive else 1000
 
     type_filter = _parse_type_from_params(args)
     if type_filter:

--- a/src/fabric_cli/utils/fab_ui.py
+++ b/src/fabric_cli/utils/fab_ui.py
@@ -301,9 +301,11 @@ def print_entries_unix_style(
     # Adjust this value for more space if needed
     widths = [w + 2 for w in widths]
     if header:
-        print_grey(_format_unix_style_field(fields, widths), to_stderr=False)
-        # Print a separator line, offset of 1 for each field
-        print_grey("-" * (sum(widths) + len(widths)), to_stderr=False)
+        header_line = _format_unix_style_field(fields, widths)
+        print_grey(header_line, to_stderr=False)
+        # Each column uses widths[i] chars + 1 space separator between columns
+        table_width = sum(widths) + len(widths) - 1
+        print_grey("-" * table_width, to_stderr=False)
 
     for entry in _entries:
         print_grey(_format_unix_style_entry(entry, fields, widths), to_stderr=False)

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_basic_search_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_basic_search_success.yaml
@@ -288,7 +288,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50, "filter": "Type eq ''Notebook''"}'
+    body: '{"search": "fabcli000001", "pageSize": 30, "filter": "Type eq ''Notebook''"}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_jmespath_skips_empty_page_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_jmespath_skips_empty_page_success.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"search": "jmespathskip", "pageSize": 50}'
+    body: '{"search": "jmespathskip", "pageSize": 30}'
     headers:
       Accept: &id001
       - '*/*'
@@ -55,7 +55,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"continuationToken": "token-skip2", "pageSize": 50}'
+    body: '{"continuationToken": "token-skip2", "pageSize": 30}'
     headers:
       Accept: *id001
       Accept-Encoding: *id002
@@ -95,7 +95,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"continuationToken": "token-skip3", "pageSize": 50}'
+    body: '{"continuationToken": "token-skip3", "pageSize": 30}'
     headers:
       Accept: *id001
       Accept-Encoding: *id002

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_json_output_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_json_output_success.yaml
@@ -288,7 +288,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50}'
+    body: '{"search": "fabcli000001", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_long_name_details_not_truncated_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_long_name_details_not_truncated_success.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"search": "longname", "pageSize": 50}'
+    body: '{"search": "longname", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_long_name_json_not_truncated_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_long_name_json_not_truncated_success.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"search": "longname", "pageSize": 50}'
+    body: '{"search": "longname", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_long_name_truncated_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_long_name_truncated_success.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"search": "longname", "pageSize": 50}'
+    body: '{"search": "longname", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_multi_page_interactive_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_multi_page_interactive_success.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"search": "multipage", "pageSize": 50}'
+    body: '{"search": "multipage", "pageSize": 30}'
     headers:
       Accept: &id001
       - '*/*'
@@ -55,7 +55,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"continuationToken": "token-page2", "pageSize": 50}'
+    body: '{"continuationToken": "token-page2", "pageSize": 30}'
     headers:
       Accept: *id001
       Accept-Encoding: *id002

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_multi_type_eq_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_multi_type_eq_success.yaml
@@ -288,7 +288,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50, "filter": "(Type eq ''Notebook''
+    body: '{"search": "fabcli000001", "pageSize": 30, "filter": "(Type eq ''Notebook''
       or Type eq ''Report'')"}'
     headers:
       Accept:

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_ne_multi_type_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_ne_multi_type_success.yaml
@@ -288,7 +288,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50, "filter": "(Type ne ''Notebook''
+    body: '{"search": "fabcli000001", "pageSize": 30, "filter": "(Type ne ''Notebook''
       and Type ne ''Report'')"}'
     headers:
       Accept:

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_no_items_display_after_jmespath_filters_all_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_no_items_display_after_jmespath_filters_all_success.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"search": "jmespathempty", "pageSize": 50}'
+    body: '{"search": "jmespathempty", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_no_results_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_no_results_success.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"search": "xyznonexistent98765zzz", "pageSize": 50}'
+    body: '{"search": "xyznonexistent98765zzz", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_single_page_no_prompt_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_single_page_no_prompt_success.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"search": "singlepage", "pageSize": 50}'
+    body: '{"search": "singlepage", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_type_case_insensitive_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_type_case_insensitive_success.yaml
@@ -186,7 +186,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50, "filter": "Type eq ''Lakehouse''"}'
+    body: '{"search": "fabcli000001", "pageSize": 30, "filter": "Type eq ''Lakehouse''"}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_with_jmespath_query_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_with_jmespath_query_success.yaml
@@ -288,7 +288,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50}'
+    body: '{"search": "fabcli000001", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_with_long_output_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_with_long_output_success.yaml
@@ -288,7 +288,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50}'
+    body: '{"search": "fabcli000001", "pageSize": 30}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_with_ne_filter_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_with_ne_filter_success.yaml
@@ -288,7 +288,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50, "filter": "Type ne ''Notebook''"}'
+    body: '{"search": "fabcli000001", "pageSize": 30, "filter": "Type ne ''Notebook''"}'
     headers:
       Accept:
       - '*/*'

--- a/tests/test_commands/recordings/test_commands/test_find/test_find_with_type_filter_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_find/test_find_with_type_filter_success.yaml
@@ -186,7 +186,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"search": "fabcli000001", "pageSize": 50, "filter": "Type eq ''Lakehouse''"}'
+    body: '{"search": "fabcli000001", "pageSize": 30, "filter": "Type eq ''Lakehouse''"}'
     headers:
       Accept:
       - '*/*'


### PR DESCRIPTION
 Two small `find` command fixes:
 
 1. **Separator line off-by-one**: The header separator was 1 character wider than the header/data rows, causing a single dash to wrap to the next line when truncation fits the table exactly to terminal width.
 2. **Interactive page size**: Reduced from 50 to 30 so results fit on screen without scrolling.