### PR TITLE
fix: show cicd version is available message only for deploy command

### DIFF
--- a/.changes/unreleased/fixed-20260427-141642.yaml
+++ b/.changes/unreleased/fixed-20260427-141642.yaml
@@ -1,0 +1,6 @@
+kind: fixed
+body: Show "New cicd version available" message only for deploy command
+time: 2026-04-27T14:16:42.598478256Z
+custom:
+    Author: aviatco
+    AuthorLink: https://github.com/aviatco

--- a/src/fabric_cli/commands/fs/deploy/fab_fs_deploy_config_file.py
+++ b/src/fabric_cli/commands/fs/deploy/fab_fs_deploy_config_file.py
@@ -4,8 +4,6 @@
 import json
 from argparse import Namespace
 
-from fabric_cicd import append_feature_flag, configure_external_file_logging, deploy_with_config, disable_file_logging  # type: ignore
-
 from fabric_cli.core import fab_constant, fab_state_config
 from fabric_cli.core import fab_logger
 from fabric_cli.core.fab_exceptions import FabricCLIError
@@ -16,6 +14,7 @@ from fabric_cli.utils.fab_util import get_dict_from_params
 
 def deploy_with_config_file(args: Namespace) -> None:
     """deploy fabric items to a workspace using a configuration file and target environment - delegates to CICD library."""
+    from fabric_cicd import append_feature_flag, configure_external_file_logging, deploy_with_config, disable_file_logging  # type: ignore
 
     try:
         if fab_state_config.get_config(fab_constant.FAB_DEBUG_ENABLED) == "true":


### PR DESCRIPTION
# 📥 Pull Request

<!--
Pull request title must follows the [Conventional Commits](https://www.conventionalcommits.org/) format (`type(scope): subject`).

**type**: Must be one of the following:

- `feat`: A new feature
- `fix`: A bug fix
- `docs`: Documentation only changes
- `style`: Changes that do not affect the meaning of the code (e.g., formatting)
- `refactor`: A code change that neither fixes a bug nor adds a feature
- `perf`: A code change that improves performance
- `test`: Adding missing tests or correcting existing tests
- `chore`: Changes to the build process or auxiliary tools
- `build`: Changes that affect the build system or external dependencies
- `ci`: Changes to CI configuration files and scripts
- `revert`: Reverts a previous commit
-->

## ✨ Description of new changes
This pull request fixes an issue where the "New cicd version available" message was shown outside of the intended context. Now, the message will only appear when the deploy command is used. Additionally, the import of certain `fabric_cicd` functions has been moved inside the relevant function for better scope management.

Bug fix:

* The "New cicd version available" message is now shown only for the deploy command, preventing it from appearing in unrelated contexts. (.changes/unreleased/fixed-20260427-141642.yaml)

Code organization:

* Moved the import of `fabric_cicd` functions (`append_feature_flag`, `configure_external_file_logging`, `deploy_with_config`, `disable_file_logging`) inside the `deploy_with_config_file` function in `fab_fs_deploy_config_file.py` to limit their scope and potentially improve performance. [[1]](diffhunk://#diff-73cf2e64d00bd2eb88c72fbdabbb78a6344004948881fa919f5fc32fd6028e77L7-L8) [[2]](diffhunk://#diff-73cf2e64d00bd2eb88c72fbdabbb78a6344004948881fa919f5fc32fd6028e77R17)
<!--
Provide a clear and concise description of the changes.

- **Summary**: What is the change and what issue does it fix?
- **Context**: Why is this change needed? What is the motivation?
- **Dependencies**: Are there any dependencies required for this change?
-->