### PR TITLE
fix: Use bracket syntax in find type suggestion hint

### DIFF
--- a/src/fabric_cli/commands/find/fab_find.py
+++ b/src/fabric_cli/commands/find/fab_find.py
@@ -243,7 +243,7 @@ def _parse_type_from_params(args: Namespace) -> dict[str, Any] | None:
                 v for k, v in all_types_lower.items() if t_lower in k or k in t_lower
             ]
             hint = (
-                f" Did you mean {', '.join(close)}?"
+                f" Did you mean [{','.join(close)}]?"
                 if close
                 else " Run 'find --help' to see examples."
             )


### PR DESCRIPTION
# 📥 Pull Request

## ✨ Description of new changes

The 'Did you mean' hint for unrecognized types now shows bracket syntax (e.g. [Notebook,Map]) so the suggestion is directly usable with -P type=[Notebook,Map].