### PR TITLE
feat: support Python 3.14 by removing upper bound on requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,14 @@ description = "Command-line tool for Microsoft Fabric"
 readme = "README.md"
 dynamic = ["version"]
 license = "MIT"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
## Summary

Remove the `<3.14` upper bound from `requires-python` in `pyproject.toml` and add Python 3.14 to the classifiers list. The `msal` dependency — which was the original blocker for Python 3.14 support — has been compatible since v1.35.0 (~3 months ago). There is no longer any known incompatibility that justifies the upper bound.

## Changes

1. **`requires-python`**: Changed from `">=3.10,<3.14"` to `">=3.10"` — removes the artificial upper bound
2. **Classifiers**: Added `"Programming Language :: Python :: 3.14"` to the classifiers list

## Rationale

- The original blocker was `msal` not supporting Python 3.14 (referenced in #89). `msal` added Python 3.14 support in v1.35.0, released ~3 months ago
- Upper bounds on `python_requires` are discouraged by PEP 440 best practices unless there is a known incompatibility
- This change is backward-compatible — all existing supported Python versions (3.10–3.13) continue to work

## Testing

- The change is a single-line metadata update + one classifier addition
- No code changes required
- Existing CI and test suite remain unaffected

Resolves: #236