### PR TITLE
docs: add disclaimer about preview APIs and items

### DIFF
--- a/.changes/unreleased/docs-preview-disclaimer.yaml
+++ b/.changes/unreleased/docs-preview-disclaimer.yaml
@@ -1,4 +1,4 @@
 kind: docs
-body: Add a note to the docs landing page clarifying that the GA CLI may support preview items and rely on preview APIs that aren't covered by the standard Fabric SLA
+body: Add a Release status section to the docs landing page indicating GA status, pointing to the release notes for the current version, and noting that the CLI may support Fabric items and rely on Fabric public APIs that are still in preview (and therefore not covered by the standard Fabric SLA)
 custom:
   Author: HasanAboShally

--- a/.changes/unreleased/docs-preview-disclaimer.yaml
+++ b/.changes/unreleased/docs-preview-disclaimer.yaml
@@ -1,0 +1,4 @@
+kind: docs
+body: Add a note to the docs landing page clarifying that the GA CLI may support preview items and rely on preview APIs that aren't covered by the standard Fabric SLA
+custom:
+  Author: HasanAboShally

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,6 @@ hide:
 
 The Fabric CLI (`fab`) gives you command-line access to Microsoft Fabric. Manage workspaces, run pipelines, and automate data workflows - all from your terminal.
 
-!!! note "Preview APIs and items"
-    The Fabric CLI is generally available (GA), but it may support Fabric items that are still in preview, and some commands may rely on Fabric public APIs that are still in [preview](https://learn.microsoft.com/rest/api/fabric/articles/api-structure#api-endpoints). Preview items and APIs aren't covered by the standard Fabric SLA.
-
 ---
 
 ## Why use the CLI?
@@ -28,6 +25,13 @@ Get powerful control over your Fabric resources:
 - **Autocompletion** - Enable [tab completion](./essentials/autocompletion.md) for commands, subcommands, and flags.
 - **Cross-platform** - Windows Terminal, macOS Terminal, Linux shells.
 - **Built on public APIs** - Fabric REST, OneLake, and Microsoft.Fabric ARM endpoints.
+
+
+## Release status
+
+The Fabric CLI is generally available (GA). For the current version and changelog, see the [release notes](./release-notes.md). Run `fab --version` to check your installed version.
+
+**Note:** The CLI may support Fabric items that are still in preview, and some commands may rely on Fabric public APIs that are still in [preview](https://learn.microsoft.com/rest/api/fabric/articles/api-structure#api-endpoints). Preview items and APIs aren't covered by the standard Fabric SLA.
 
 
 ## Get started

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Get powerful control over your Fabric resources:
 
 The Fabric CLI is generally available (GA). For the current version and changelog, see the [release notes](./release-notes.md). Run `fab --version` to check your installed version.
 
-**Note:** The CLI may support Fabric items that are still in preview, and some commands may rely on Fabric public APIs that are still in [preview](https://learn.microsoft.com/rest/api/fabric/articles/api-structure#api-endpoints). Preview items and APIs aren't covered by the standard Fabric SLA.
+**Note:** The CLI may support Fabric items that are still in preview, and some commands may rely on Fabric public APIs that are still in [preview](https://learn.microsoft.com/rest/api/fabric/articles/api-structure#api-endpoints). Preview items and APIs aren't covered by the [Microsoft Fabric SLA](https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services).
 
 
 ## Get started

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ hide:
 
 The Fabric CLI (`fab`) gives you command-line access to Microsoft Fabric. Manage workspaces, run pipelines, and automate data workflows - all from your terminal.
 
+!!! note "Preview APIs and items"
+    The Fabric CLI is generally available (GA), but it may support Fabric items that are still in preview, and some commands may rely on Fabric public APIs that are still in [preview](https://learn.microsoft.com/rest/api/fabric/articles/api-structure#api-endpoints). Preview items and APIs aren't covered by the standard Fabric SLA.
+
 ---
 
 ## Why use the CLI?


### PR DESCRIPTION
Adds a **Release status** section to the docs landing page. The section states that the Fabric CLI is generally available (GA), points to the [release notes](./docs/release-notes.md) for the current version and changelog, mentions `fab --version` to check the installed version, and ends with a short note: the CLI may support Fabric items that are still in preview, and some commands may rely on Fabric public APIs that are still in [preview](https://learn.microsoft.com/rest/api/fabric/articles/api-structure#api-endpoints) — and those preview items and APIs aren't covered by the [Microsoft Fabric SLA](https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services).

### Changes
- `docs/index.md`: add a new `## Release status` section between *What you can do* and *Get started*. Uses plain prose with a bolded `**Note:**` (no admonition extension is enabled in `mkdocs.yml`, so admonitions render as raw `!!!` text).
- `.changes/unreleased/docs-preview-disclaimer.yaml`: changie entry (kind: docs).
