### PR TITLE
refactor: validate format for PIT restore of SQL DB

### DIFF
--- a/.changes/unreleased/optimization-20260611-135540.yaml
+++ b/.changes/unreleased/optimization-20260611-135540.yaml
@@ -1,0 +1,6 @@
+kind: optimization
+body: Validates format of the point-in-time restore on SQL DBs
+time: 2026-06-11T13:55:40.307562924Z
+custom:
+    Author: v-alexmoraru
+    AuthorLink: https://github.com/v-alexmoraru

--- a/src/fabric_cli/client/fab_api_client.py
+++ b/src/fabric_cli/client/fab_api_client.py
@@ -26,11 +26,11 @@ from fabric_cli.utils import fab_error_parser as utils_errors
 from fabric_cli.utils import fab_files as files_utils
 from fabric_cli.utils import fab_ui as utils_ui
 from fabric_cli.utils.fab_http_polling_utils import get_polling_interval
+from fabric_cli.utils.fab_util import GUID_PATTERN_STR
 
 _HOST_APP_VERSION_RE = re.compile(r"\d+(\.\d+){0,2}(-[a-zA-Z0-9\.-]+)?")
 
-GUID_PATTERN = r"([a-f0-9\-]{36})"
-FABRIC_WORKSPACE_URI_PATTERN = rf"workspaces/{GUID_PATTERN}"
+FABRIC_WORKSPACE_URI_PATTERN = rf"workspaces/{GUID_PATTERN_STR}"
 
 # Module-level reusable session for connection pooling
 _shared_session = None
@@ -552,7 +552,7 @@ def _transform_workspace_url_for_private_link_if_needed(
         # For OneLake APIs, check if first segment is a valid GUID
         uri_segments = uri.strip("/").split("/")
         if uri_segments and re.match(
-            rf"^{GUID_PATTERN}$", uri_segments[0], re.IGNORECASE
+            rf"^{GUID_PATTERN_STR}$", uri_segments[0], re.IGNORECASE
         ):
             workspace_id = uri_segments[0]
     elif "admin/" in uri.lower():

--- a/src/fabric_cli/errors/mkdir.py
+++ b/src/fabric_cli/errors/mkdir.py
@@ -23,7 +23,7 @@ class MkdirErrors:
     @staticmethod
     def invalid_restore_point_in_time() -> str:
         return (
-            "Invalid restorepointintime format. "
+            "Invalid restorePointInTime format. "
             "Please provide an ISO 8601 timestamp with timezone (e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00+00:00')"
         )
 
@@ -31,7 +31,7 @@ class MkdirErrors:
     def missing_restore_params(missing: list[str]) -> str:
         return (
             f"Missing required parameter(s) for restore mode: {', '.join(missing)}. "
-            "Example: -P mode=restore,restorepointintime=2024-01-15T10:30:00Z,itemid=<guid>,workspaceid=<guid>"
+            "Example: -P mode=restore,restorePointInTime=2024-01-15T10:30:00Z,itemId=<guid>,workspaceId=<guid>"
         )
 
     @staticmethod

--- a/src/fabric_cli/errors/mkdir.py
+++ b/src/fabric_cli/errors/mkdir.py
@@ -19,3 +19,26 @@ class MkdirErrors:
     @staticmethod
     def folder_name_exists() -> str:
         return "A folder with the same name already exists"
+
+    @staticmethod
+    def invalid_restore_point_in_time() -> str:
+        return (
+            "Invalid restorePointInTime format. "
+            "Please provide an ISO 8601 timestamp with timezone (e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00+00:00')"
+        )
+
+    @staticmethod
+    def missing_restore_params() -> str:
+        return (
+            "When mode=restore, the following parameters are required: "
+            "restorePointInTime, itemId, workspaceId. "
+            "Example: -P mode=restore,restorePointInTime=2024-01-15T10:30:00Z,itemId=<guid>,workspaceId=<guid>"
+        )
+
+    @staticmethod
+    def invalid_restore_mode() -> str:
+        return (
+            "Invalid mode for SQLDatabase creation. "
+            "Supported modes: 'restore' for point-in-time restore. "
+            "Omit mode parameter for standard database creation."
+        )

--- a/src/fabric_cli/errors/mkdir.py
+++ b/src/fabric_cli/errors/mkdir.py
@@ -28,16 +28,17 @@ class MkdirErrors:
         )
 
     @staticmethod
-    def missing_restore_params(missing: list[str]) -> str:
+    def missing_restore_params() -> str:
         return (
-            f"Missing required parameter(s) for restore mode: {', '.join(missing)}. "
+            "Missing required parameter(s) for restore mode. "
+            "Required: restorePointInTime, itemId, workspaceId. "
             "Example: -P mode=restore,restorePointInTime=2024-01-15T10:30:00Z,itemId=<guid>,workspaceId=<guid>"
         )
 
     @staticmethod
-    def invalid_restore_mode() -> str:
+    def invalid_creation_mode(mode: str) -> str:
         return (
-            "Invalid mode for SQLDatabase creation. "
-            "Supported modes: 'restore' for point-in-time restore. "
+            f"Invalid mode '{mode}' for SQLDatabase creation. "
+            "Supported modes: 'restore'. "
             "Omit mode parameter for standard database creation."
         )

--- a/src/fabric_cli/errors/mkdir.py
+++ b/src/fabric_cli/errors/mkdir.py
@@ -23,16 +23,15 @@ class MkdirErrors:
     @staticmethod
     def invalid_restore_point_in_time() -> str:
         return (
-            "Invalid restorePointInTime format. "
+            "Invalid restorepointintime format. "
             "Please provide an ISO 8601 timestamp with timezone (e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00+00:00')"
         )
 
     @staticmethod
-    def missing_restore_params() -> str:
+    def missing_restore_params(missing: list[str]) -> str:
         return (
-            "When mode=restore, the following parameters are required: "
-            "restorePointInTime, itemId, workspaceId. "
-            "Example: -P mode=restore,restorePointInTime=2024-01-15T10:30:00Z,itemId=<guid>,workspaceId=<guid>"
+            f"Missing required parameter(s) for restore mode: {', '.join(missing)}. "
+            "Example: -P mode=restore,restorepointintime=2024-01-15T10:30:00Z,itemid=<guid>,workspaceid=<guid>"
         )
 
     @staticmethod

--- a/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
@@ -14,7 +14,6 @@ from fabric_cli.core.fab_exceptions import FabricCLIError
 from fabric_cli.core.fab_types import ItemType
 from fabric_cli.core.hiearchy.fab_hiearchy import Item
 from fabric_cli.errors import ErrorMessages
-from fabric_cli.errors.mkdir import MkdirErrors
 from fabric_cli.utils import fab_ui as utils_ui
 from fabric_cli.utils.fab_util import is_valid_guid, is_valid_iso8601_timestamp
 
@@ -235,14 +234,14 @@ def add_type_specific_payload(item: Item, args, payload):
                     or not source_workspace_id
                 ):
                     raise FabricCLIError(
-                        MkdirErrors.missing_restore_params(),
+                        ErrorMessages.Mkdir.missing_restore_params(),
                         fab_constant.ERROR_INVALID_INPUT,
                     )
 
                 # Validate restorePointInTime format (ISO 8601 with timezone)
                 if not is_valid_iso8601_timestamp(restore_point_in_time):
                     raise FabricCLIError(
-                        MkdirErrors.invalid_restore_point_in_time(),
+                        ErrorMessages.Mkdir.invalid_restore_point_in_time(),
                         fab_constant.ERROR_INVALID_INPUT,
                     )
 
@@ -270,7 +269,7 @@ def add_type_specific_payload(item: Item, args, payload):
             elif mode:
                 # Invalid mode specified
                 raise FabricCLIError(
-                    MkdirErrors.invalid_creation_mode(mode),
+                    ErrorMessages.Mkdir.invalid_creation_mode(mode),
                     fab_constant.ERROR_INVALID_INPUT,
                 )
 

--- a/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
@@ -4,7 +4,9 @@
 import base64
 import json
 import os
+import re
 from argparse import Namespace
+from datetime import datetime
 
 from fabric_cli.client import fab_api_azure as azure_api
 from fabric_cli.client import fab_api_managedprivateendpoint as mpe_api
@@ -14,7 +16,35 @@ from fabric_cli.core.fab_exceptions import FabricCLIError
 from fabric_cli.core.fab_types import ItemType
 from fabric_cli.core.hiearchy.fab_hiearchy import Item
 from fabric_cli.errors import ErrorMessages
+from fabric_cli.errors.mkdir import MkdirErrors
 from fabric_cli.utils import fab_ui as utils_ui
+
+# GUID pattern for validation
+GUID_PATTERN = re.compile(
+    r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+)
+
+
+def is_valid_guid(value: str) -> bool:
+    """Validate that a string is a valid GUID format."""
+    return bool(GUID_PATTERN.match(value))
+
+
+def is_valid_iso8601_timestamp(value: str) -> bool:
+    """
+    Validate that a string is a valid ISO 8601 timestamp with timezone.
+    Accepts formats like:
+    - 2024-01-15T10:30:00Z
+    - 2024-01-15T10:30:00+00:00
+    - 2024-01-15T10:30:00.123456Z
+    """
+    # ISO 8601 pattern with timezone
+    iso8601_patterns = [
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$",  # UTC with Z suffix
+        # With offset
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?[+-]\d{2}:\d{2}$",
+    ]
+    return any(re.match(pattern, value) for pattern in iso8601_patterns)
 
 
 def add_type_specific_payload(item: Item, args, payload):
@@ -218,6 +248,65 @@ def add_type_specific_payload(item: Item, args, payload):
                 ]
             }
 
+        case ItemType.SQL_DATABASE:
+            mode = params.get("mode", "").lower()
+
+            if mode == "restore":
+                # Point-in-time restore mode
+                restore_point_in_time = params.get("restorepointintime")
+                source_item_id = params.get("itemid")
+                source_workspace_id = params.get("workspaceid")
+
+                # Validate all required parameters are present
+                missing_params = []
+                if not restore_point_in_time:
+                    missing_params.append("restorePointInTime")
+                if not source_item_id:
+                    missing_params.append("itemId")
+                if not source_workspace_id:
+                    missing_params.append("workspaceId")
+
+                if missing_params:
+                    raise FabricCLIError(
+                        MkdirErrors.missing_restore_params(),
+                        fab_constant.ERROR_INVALID_INPUT,
+                    )
+
+                # Validate restorePointInTime format (ISO 8601 with timezone)
+                if not is_valid_iso8601_timestamp(restore_point_in_time):
+                    raise FabricCLIError(
+                        MkdirErrors.invalid_restore_point_in_time(),
+                        fab_constant.ERROR_INVALID_INPUT,
+                    )
+
+                # Validate GUID formats
+                if not is_valid_guid(source_item_id):
+                    raise FabricCLIError(
+                        ErrorMessages.Common.invalid_guid("itemId"),
+                        fab_constant.ERROR_INVALID_GUID,
+                    )
+                if not is_valid_guid(source_workspace_id):
+                    raise FabricCLIError(
+                        ErrorMessages.Common.invalid_guid("workspaceId"),
+                        fab_constant.ERROR_INVALID_GUID,
+                    )
+
+                payload_dict["creationPayload"] = {
+                    "creationMode": "Restore",
+                    "sourceDatabaseReference": {
+                        "referenceType": "ById",
+                        "itemId": source_item_id,
+                        "workspaceId": source_workspace_id,
+                    },
+                    "restorePointInTime": restore_point_in_time,
+                }
+            elif mode and mode != "":
+                # Invalid mode specified
+                raise FabricCLIError(
+                    MkdirErrors.invalid_restore_mode(),
+                    fab_constant.ERROR_INVALID_INPUT,
+                )
+
     return payload_dict
 
 
@@ -344,6 +433,13 @@ def get_params_per_item_type(item: Item):
         case ItemType.MOUNTED_DATA_FACTORY:
             required_params = ["subscriptionId",
                                "resourceGroup", "factoryName"]
+        case ItemType.SQL_DATABASE:
+            optional_params = [
+                "mode (restore for point-in-time restore)",
+                "restorePointInTime (ISO 8601 timestamp, e.g. 2024-01-15T10:30:00Z)",
+                "itemId (source database GUID)",
+                "workspaceId (source workspace GUID)",
+            ]
 
     return required_params, optional_params
 

--- a/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
@@ -4,7 +4,6 @@
 import base64
 import json
 import os
-import re
 from argparse import Namespace
 
 from fabric_cli.client import fab_api_azure as azure_api
@@ -17,38 +16,7 @@ from fabric_cli.core.hiearchy.fab_hiearchy import Item
 from fabric_cli.errors import ErrorMessages
 from fabric_cli.errors.mkdir import MkdirErrors
 from fabric_cli.utils import fab_ui as utils_ui
-
-# GUID pattern for validation
-GUID_PATTERN = re.compile(
-    r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-)
-
-# ISO 8601 timestamp patterns for validation
-ISO8601_UTC_PATTERN = re.compile(
-    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z"
-)
-ISO8601_OFFSET_PATTERN = re.compile(
-    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?[+-]\d{2}:\d{2}"
-)
-
-
-def is_valid_guid(value: str) -> bool:
-    """Validate that a string is a valid GUID format."""
-    return bool(GUID_PATTERN.match(value))
-
-
-def is_valid_iso8601_timestamp(value: str) -> bool:
-    """
-    Validate that a string is a valid ISO 8601 timestamp with timezone.
-    Accepts formats like:
-    - 2024-01-15T10:30:00Z
-    - 2024-01-15T10:30:00+00:00
-    - 2024-01-15T10:30:00.123456Z
-    """
-    return bool(
-        ISO8601_UTC_PATTERN.fullmatch(value)
-        or ISO8601_OFFSET_PATTERN.fullmatch(value)
-    )
+from fabric_cli.utils.fab_util import is_valid_guid, is_valid_iso8601_timestamp
 
 
 def add_type_specific_payload(item: Item, args, payload):
@@ -140,8 +108,7 @@ def add_type_specific_payload(item: Item, args, payload):
                     item.parent,
                     "DigitalTwinBuilder",
                 )
-                _digital_twin_builder_id = mkdir_item.exec(
-                    _digital_twin_builder, args)
+                _digital_twin_builder_id = mkdir_item.exec(_digital_twin_builder, args)
 
             payload_dict["creationPayload"] = {
                 "digitalTwinBuilderItemReference": {
@@ -180,8 +147,7 @@ def add_type_specific_payload(item: Item, args, payload):
                 payload_folder,
             )
 
-            payload_dict["definition"] = _create_payload(
-                payload_path, params, _type)
+            payload_dict["definition"] = _create_payload(payload_path, params, _type)
 
         case ItemType.REPORT:
             payload_folder = "Blank.Report"
@@ -239,8 +205,7 @@ def add_type_specific_payload(item: Item, args, payload):
                 "dataFactoryResourceId": f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.DataFactory/factories/{factory_name}"
             }
             json_str = json.dumps(data)
-            encoded_content = base64.b64encode(
-                json_str.encode("utf-8")).decode("utf-8")
+            encoded_content = base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
 
             payload_dict["definition"] = {
                 "parts": [
@@ -264,17 +229,13 @@ def add_type_specific_payload(item: Item, args, payload):
                 source_workspace_id = params.get("workspaceid")
 
                 # Validate all required parameters are present
-                missing_params = []
-                if not restore_point_in_time:
-                    missing_params.append("restorePointInTime")
-                if not source_item_id:
-                    missing_params.append("itemId")
-                if not source_workspace_id:
-                    missing_params.append("workspaceId")
-
-                if missing_params:
+                if (
+                    not restore_point_in_time
+                    or not source_item_id
+                    or not source_workspace_id
+                ):
                     raise FabricCLIError(
-                        MkdirErrors.missing_restore_params(missing_params),
+                        MkdirErrors.missing_restore_params(),
                         fab_constant.ERROR_INVALID_INPUT,
                     )
 
@@ -309,7 +270,7 @@ def add_type_specific_payload(item: Item, args, payload):
             elif mode:
                 # Invalid mode specified
                 raise FabricCLIError(
-                    MkdirErrors.invalid_restore_mode(),
+                    MkdirErrors.invalid_creation_mode(mode),
                     fab_constant.ERROR_INVALID_INPUT,
                 )
 
@@ -392,8 +353,7 @@ def _create_payload(directory, params, type=None, semantic_model_id=None, encode
                 with open(full_path, "rb") as file:
                     content = file.read()
                     encoded_content = (
-                        base64.b64encode(content).decode(
-                            "utf-8") if encode else content
+                        base64.b64encode(content).decode("utf-8") if encode else content
                     )
 
             # Add file data to parts
@@ -422,8 +382,7 @@ def get_params_per_item_type(item: Item):
         case ItemType.WAREHOUSE:
             optional_params = ["enableCaseInsensitive"]
         case ItemType.KQL_DATABASE:
-            optional_params = ["dbType", "eventhouseId",
-                               "clusterUri", "databaseName"]
+            optional_params = ["dbType", "eventhouseId", "clusterUri", "databaseName"]
         case ItemType.DIGITAL_TWIN_BUILDER_FLOW:
             optional_params = ["digitalTwinBuilderId"]
         case ItemType.MIRRORED_DATABASE:
@@ -437,8 +396,7 @@ def get_params_per_item_type(item: Item):
         case ItemType.REPORT:
             optional_params = ["semanticModelId"]
         case ItemType.MOUNTED_DATA_FACTORY:
-            required_params = ["subscriptionId",
-                               "resourceGroup", "factoryName"]
+            required_params = ["subscriptionId", "resourceGroup", "factoryName"]
         case ItemType.SQL_DATABASE:
             # Note: params are lowercased during parsing, for internal lookups
             # These camelCase names are for user-facing help text display only.
@@ -455,10 +413,8 @@ def get_params_per_item_type(item: Item):
 def show_params_desc(params, type, required_params=None, optional_params=None):
 
     if not params:
-        required_params_filtered = [p for p in (
-            required_params or []) if p is not None]
-        optional_params_filtered = [p for p in (
-            optional_params or []) if p is not None]
+        required_params_filtered = [p for p in (required_params or []) if p is not None]
+        optional_params_filtered = [p for p in (optional_params or []) if p is not None]
 
         # Construct the parts of the message conditionally
         required_param_list = "\n  ".join(sorted(required_params_filtered))
@@ -472,11 +428,9 @@ def show_params_desc(params, type, required_params=None, optional_params=None):
             ]
 
             if required_param_list:
-                message_parts.append(
-                    f"\n\nRequired params:\n  {required_param_list}")
+                message_parts.append(f"\n\nRequired params:\n  {required_param_list}")
             if optional_param_list:
-                message_parts.append(
-                    f"\n\nOptional params:\n  {optional_param_list}")
+                message_parts.append(f"\n\nOptional params:\n  {optional_param_list}")
 
         utils_ui.print("".join(message_parts) + "\n")
 
@@ -593,8 +547,7 @@ def _validate_and_get_on_premises_gateway_credential_values(cred_values):
     ]
     if len(missing_params) > 0:
         raise FabricCLIError(
-            ErrorMessages.Common.missing_onpremises_gateway_parameters(
-                missing_params),
+            ErrorMessages.Common.missing_onpremises_gateway_parameters(missing_params),
             fab_constant.ERROR_INVALID_INPUT,
         )
 
@@ -610,8 +563,7 @@ def _validate_and_get_on_premises_gateway_credential_values(cred_values):
         )
 
     return [
-        {key: item[key.lower()]
-         for key in param_values_keys if key.lower() in item}
+        {key: item[key.lower()] for key in param_values_keys if key.lower() in item}
         for item in cred_values
     ]
 
@@ -654,8 +606,7 @@ def get_connection_config_from_params(payload, con_type, con_type_def, params):
         )
     provided_params = params.get("connectiondetails").get("parameters")
 
-    supported_creation_methods = [m["name"]
-                                  for m in con_type_def["creationMethods"]]
+    supported_creation_methods = [m["name"] for m in con_type_def["creationMethods"]]
     if not params.get("connectiondetails").get("creationmethod"):
         if provided_params:
             # We default to pick the first creation method that matches the provided parameters
@@ -717,8 +668,7 @@ def get_connection_config_from_params(payload, con_type, con_type_def, params):
             # Get required and optional parameters from the creation method
             req_params_str = ", ".join(required_params)
             opt_params_str = ", ".join(
-                [p["name"]
-                    for p in creation_method["parameters"] if not p["required"]]
+                [p["name"] for p in creation_method["parameters"] if not p["required"]]
             )
             raise FabricCLIError(
                 f"Parameters are required for the connection creation method. Required parameters are: {req_params_str}. Optional parameters are: {opt_params_str}",
@@ -824,8 +774,7 @@ def get_connection_config_from_params(payload, con_type, con_type_def, params):
         provided_cred_params.pop("skiptestconnection")
 
     is_on_premises_gateway = (
-        connection_request.get(
-            "connectivityType").lower() == "onpremisesgateway"
+        connection_request.get("connectivityType").lower() == "onpremisesgateway"
     )
     connection_params = _validate_credential_params(
         cred_type, provided_cred_params, is_on_premises_gateway
@@ -863,8 +812,7 @@ def find_vnet_subnet(vnet_name, subnet_name) -> tuple:
         vnet_req = azure_api.list_vnets_azure(_args)
         vnets = json.loads(vnet_req.text)["value"]
         vnet = next(
-            (item for item in vnets if item["name"].lower(
-            ) == vnet_name.lower()),
+            (item for item in vnets if item["name"].lower() == vnet_name.lower()),
             None,
         )
         if vnet:

--- a/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
@@ -6,7 +6,6 @@ import json
 import os
 import re
 from argparse import Namespace
-from datetime import datetime
 
 from fabric_cli.client import fab_api_azure as azure_api
 from fabric_cli.client import fab_api_managedprivateendpoint as mpe_api
@@ -260,15 +259,15 @@ def add_type_specific_payload(item: Item, args, payload):
                 # Validate all required parameters are present
                 missing_params = []
                 if not restore_point_in_time:
-                    missing_params.append("restorePointInTime")
+                    missing_params.append("restorepointintime")
                 if not source_item_id:
-                    missing_params.append("itemId")
+                    missing_params.append("itemid")
                 if not source_workspace_id:
-                    missing_params.append("workspaceId")
+                    missing_params.append("workspaceid")
 
                 if missing_params:
                     raise FabricCLIError(
-                        MkdirErrors.missing_restore_params(),
+                        MkdirErrors.missing_restore_params(missing_params),
                         fab_constant.ERROR_INVALID_INPUT,
                     )
 
@@ -436,9 +435,9 @@ def get_params_per_item_type(item: Item):
         case ItemType.SQL_DATABASE:
             optional_params = [
                 "mode (restore for point-in-time restore)",
-                "restorePointInTime (ISO 8601 timestamp, e.g. 2024-01-15T10:30:00Z)",
-                "itemId (source database GUID)",
-                "workspaceId (source workspace GUID)",
+                "restorepointintime (ISO 8601 timestamp, e.g. 2024-01-15T10:30:00Z)",
+                "itemid (source database GUID)",
+                "workspaceid (source workspace GUID)",
             ]
 
     return required_params, optional_params

--- a/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
@@ -23,6 +23,14 @@ GUID_PATTERN = re.compile(
     r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
 )
 
+# ISO 8601 timestamp patterns for validation
+ISO8601_UTC_PATTERN = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z"
+)
+ISO8601_OFFSET_PATTERN = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?[+-]\d{2}:\d{2}"
+)
+
 
 def is_valid_guid(value: str) -> bool:
     """Validate that a string is a valid GUID format."""
@@ -37,13 +45,10 @@ def is_valid_iso8601_timestamp(value: str) -> bool:
     - 2024-01-15T10:30:00+00:00
     - 2024-01-15T10:30:00.123456Z
     """
-    # ISO 8601 pattern with timezone
-    iso8601_patterns = [
-        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$",  # UTC with Z suffix
-        # With offset
-        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?[+-]\d{2}:\d{2}$",
-    ]
-    return any(re.match(pattern, value) for pattern in iso8601_patterns)
+    return bool(
+        ISO8601_UTC_PATTERN.fullmatch(value)
+        or ISO8601_OFFSET_PATTERN.fullmatch(value)
+    )
 
 
 def add_type_specific_payload(item: Item, args, payload):
@@ -299,7 +304,7 @@ def add_type_specific_payload(item: Item, args, payload):
                     },
                     "restorePointInTime": restore_point_in_time,
                 }
-            elif mode and mode != "":
+            elif mode:
                 # Invalid mode specified
                 raise FabricCLIError(
                     MkdirErrors.invalid_restore_mode(),
@@ -434,10 +439,10 @@ def get_params_per_item_type(item: Item):
                                "resourceGroup", "factoryName"]
         case ItemType.SQL_DATABASE:
             optional_params = [
-                "mode (restore for point-in-time restore)",
-                "restorepointintime (ISO 8601 timestamp, e.g. 2024-01-15T10:30:00Z)",
-                "itemid (source database GUID)",
-                "workspaceid (source workspace GUID)",
+                "mode",
+                "restorePointInTime",
+                "itemId",
+                "workspaceId",
             ]
 
     return required_params, optional_params

--- a/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_mkdir_utils.py
@@ -257,6 +257,8 @@ def add_type_specific_payload(item: Item, args, payload):
 
             if mode == "restore":
                 # Point-in-time restore mode
+                # Note: params are pre-lowercased, but error messages use camelCase
+                # to match get_params_per_item_type() output
                 restore_point_in_time = params.get("restorepointintime")
                 source_item_id = params.get("itemid")
                 source_workspace_id = params.get("workspaceid")
@@ -264,11 +266,11 @@ def add_type_specific_payload(item: Item, args, payload):
                 # Validate all required parameters are present
                 missing_params = []
                 if not restore_point_in_time:
-                    missing_params.append("restorepointintime")
+                    missing_params.append("restorePointInTime")
                 if not source_item_id:
-                    missing_params.append("itemid")
+                    missing_params.append("itemId")
                 if not source_workspace_id:
-                    missing_params.append("workspaceid")
+                    missing_params.append("workspaceId")
 
                 if missing_params:
                     raise FabricCLIError(
@@ -438,6 +440,8 @@ def get_params_per_item_type(item: Item):
             required_params = ["subscriptionId",
                                "resourceGroup", "factoryName"]
         case ItemType.SQL_DATABASE:
+            # Note: params are lowercased during parsing, for internal lookups
+            # These camelCase names are for user-facing help text display only.
             optional_params = [
                 "mode",
                 "restorePointInTime",

--- a/src/fabric_cli/utils/fab_util.py
+++ b/src/fabric_cli/utils/fab_util.py
@@ -15,6 +15,7 @@ The module includes functions for:
 - Path and string processing
 - OS-specific operations
 - Azure capacity configuration management
+- Format validation (GUIDs, timestamps)
 """
 
 import json
@@ -26,6 +27,49 @@ from typing import Any
 from fabric_cli.core import fab_constant, fab_state_config
 from fabric_cli.core.fab_exceptions import FabricCLIError
 from fabric_cli.errors import ErrorMessages
+
+# Validation patterns
+GUID_PATTERN = re.compile(
+    r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+)
+GUID_PATTERN_STR = r"([a-f0-9\-]{36})"
+
+# ISO 8601 timestamp patterns for validation
+ISO8601_UTC_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z")
+ISO8601_OFFSET_PATTERN = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?[+-]\d{2}:\d{2}"
+)
+
+
+def is_valid_guid(value: str) -> bool:
+    """Validate that a string is a valid GUID format.
+
+    Args:
+        value: String to validate.
+
+    Returns:
+        True if the string matches GUID format, False otherwise.
+    """
+    return bool(GUID_PATTERN.match(value))
+
+
+def is_valid_iso8601_timestamp(value: str) -> bool:
+    """Validate that a string is a valid ISO 8601 timestamp with timezone.
+
+    Accepts formats like:
+    - 2024-01-15T10:30:00Z
+    - 2024-01-15T10:30:00+00:00
+    - 2024-01-15T10:30:00.123456Z
+
+    Args:
+        value: String to validate.
+
+    Returns:
+        True if the string matches ISO 8601 timestamp format with timezone, False otherwise.
+    """
+    return bool(
+        ISO8601_UTC_PATTERN.fullmatch(value) or ISO8601_OFFSET_PATTERN.fullmatch(value)
+    )
 
 
 # JSON utilities
@@ -42,6 +86,7 @@ def dumps(obj: Any, **kw) -> str:
     Raises:
         TypeError: If object contains non-serializable types other than bytes/bytearray
     """
+
     def _default(o):
         if isinstance(o, (bytes, bytearray)):
             return "__REDACTED__bytes__"
@@ -138,7 +183,7 @@ def try_get_json_value_from_string(value: str) -> Any:
     Returns:
         Parsed JSON if valid, otherwise original string
     """
-    if value.strip().startswith('[{') and value.strip().endswith('}]'):
+    if value.strip().startswith("[{") and value.strip().endswith("}]"):
         try:
             return json.loads(value)
         except json.JSONDecodeError:
@@ -198,20 +243,15 @@ def get_capacity_settings(
     """
     az_subscription_id = params.get(
         "subscriptionid",
-        fab_state_config.get_config(
-            fab_constant.FAB_DEFAULT_AZ_SUBSCRIPTION_ID
-        ),
+        fab_state_config.get_config(fab_constant.FAB_DEFAULT_AZ_SUBSCRIPTION_ID),
     )
     az_resource_group = params.get(
         "resourcegroup",
-        fab_state_config.get_config(
-            fab_constant.FAB_DEFAULT_AZ_RESOURCE_GROUP
-        ),
+        fab_state_config.get_config(fab_constant.FAB_DEFAULT_AZ_RESOURCE_GROUP),
     )
     az_default_location = params.get(
-        "location", fab_state_config.get_config(
-            fab_constant.FAB_DEFAULT_AZ_LOCATION
-        ),
+        "location",
+        fab_state_config.get_config(fab_constant.FAB_DEFAULT_AZ_LOCATION),
     )
     az_default_admin = params.get(
         "admin", fab_state_config.get_config(fab_constant.FAB_DEFAULT_AZ_ADMIN)

--- a/tests/test_utils/test_fab_cmd_mkdir_utils.py
+++ b/tests/test_utils/test_fab_cmd_mkdir_utils.py
@@ -538,7 +538,7 @@ class TestGetParamsPerItemTypeSQLDatabase:
 
         assert required == []
         assert len(optional) == 4
-        assert any("mode" in param for param in optional)
-        assert any("restorePointInTime" in param for param in optional)
-        assert any("itemId" in param for param in optional)
-        assert any("workspaceId" in param for param in optional)
+        assert "mode" in optional
+        assert "restorePointInTime" in optional
+        assert "itemId" in optional
+        assert "workspaceId" in optional

--- a/tests/test_utils/test_fab_cmd_mkdir_utils.py
+++ b/tests/test_utils/test_fab_cmd_mkdir_utils.py
@@ -370,7 +370,7 @@ class TestSQLDatabaseRestore:
                 mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-        assert "restorepointintime" in exc_info.value.message
+        assert "restorePointInTime" in exc_info.value.message
 
     def test_restore_mode_missing_item_id_failure(self, mock_sql_database_item, mock_args):
         """Test SQLDatabase restore fails when itemId is missing."""
@@ -387,7 +387,7 @@ class TestSQLDatabaseRestore:
                 mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-        assert "itemid" in exc_info.value.message
+        assert "itemId" in exc_info.value.message
 
     def test_restore_mode_missing_workspace_id_failure(self, mock_sql_database_item, mock_args):
         """Test SQLDatabase restore fails when workspaceId is missing."""
@@ -404,7 +404,7 @@ class TestSQLDatabaseRestore:
                 mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-        assert "workspaceid" in exc_info.value.message
+        assert "workspaceId" in exc_info.value.message
 
     def test_restore_mode_invalid_timestamp_format_failure(self, mock_sql_database_item, mock_args):
         """Test SQLDatabase restore fails with invalid timestamp format."""

--- a/tests/test_utils/test_fab_cmd_mkdir_utils.py
+++ b/tests/test_utils/test_fab_cmd_mkdir_utils.py
@@ -17,18 +17,14 @@ from fabric_cli.utils.fab_cmd_mkdir_utils import (
     find_mpe_connection,
     get_connection_config_from_params,
     get_params_per_item_type,
-    is_valid_guid,
-    is_valid_iso8601_timestamp,
 )
+from fabric_cli.utils.fab_util import is_valid_guid, is_valid_iso8601_timestamp
 
 
 def test_fabric_data_pipelines_workspace_identity_no_params_success():
     """Test FabricDataPipelines with WorkspaceIdentity credential type when no parameters are required."""
     # Arrange
-    payload = {
-        "displayName": "test-connection",
-        "connectivityType": "ShareableCloud"
-    }
+    payload = {"displayName": "test-connection", "connectivityType": "ShareableCloud"}
 
     con_type = "FabricDataPipelines"
     con_type_def = {
@@ -36,43 +32,44 @@ def test_fabric_data_pipelines_workspace_identity_no_params_success():
         "creationMethods": [
             {
                 "name": "FabricDataPipelines.Actions",
-                "parameters": []  # No parameters required for this creation method
+                "parameters": [],  # No parameters required for this creation method
             }
         ],
-        "supportedCredentialTypes": ["WorkspaceIdentity"]
+        "supportedCredentialTypes": ["WorkspaceIdentity"],
     }
 
     params = {
         "connectiondetails": {
             "type": "FabricDataPipelines",
-            "creationmethod": "FabricDataPipelines.Actions"
+            "creationmethod": "FabricDataPipelines.Actions",
             # No parameters provided since none are required
         },
         "credentialdetails": {
             "type": "WorkspaceIdentity"
             # No credential parameters provided since WorkspaceIdentity doesn't require any
-        }
+        },
     }
 
-    result = get_connection_config_from_params(
-        payload, con_type, con_type_def, params)
+    result = get_connection_config_from_params(payload, con_type, con_type_def, params)
 
     # Assert
     assert result["privacyLevel"] == "None"
     assert result["connectionDetails"]["type"] == "FabricDataPipelines"
-    assert result["connectionDetails"]["creationMethod"] == "FabricDataPipelines.Actions"
+    assert (
+        result["connectionDetails"]["creationMethod"] == "FabricDataPipelines.Actions"
+    )
     assert "parameters" not in result["connectionDetails"]
-    assert result["credentialDetails"]["credentials"]["credentialType"] == "WorkspaceIdentity"
+    assert (
+        result["credentialDetails"]["credentials"]["credentialType"]
+        == "WorkspaceIdentity"
+    )
     assert len(result["credentialDetails"]["credentials"].keys()) == 1
 
 
 def test_connection_with_required_params_missing_failure():
     """Test that connection creation fails when required parameters are missing."""
     # Arrange
-    payload = {
-        "displayName": "test-connection",
-        "connectivityType": "ShareableCloud"
-    }
+    payload = {"displayName": "test-connection", "connectivityType": "ShareableCloud"}
 
     con_type = "SQL"
     con_type_def = {
@@ -82,77 +79,73 @@ def test_connection_with_required_params_missing_failure():
                 "name": "SQL",
                 "parameters": [
                     {"name": "server", "required": True, "dataType": "Text"},
-                    {"name": "database", "required": True, "dataType": "Text"}
-                ]
+                    {"name": "database", "required": True, "dataType": "Text"},
+                ],
             }
         ],
-        "supportedCredentialTypes": ["Basic"]
+        "supportedCredentialTypes": ["Basic"],
     }
 
     params = {
         "connectiondetails": {
             "type": "SQL",
-            "creationmethod": "SQL"
+            "creationmethod": "SQL",
             # No parameters provided, but they are required
         },
         "credentialdetails": {
             "type": "Basic",
             "username": "testuser",
-            "password": "testpass"
-        }
+            "password": "testpass",
+        },
     }
 
     with pytest.raises(FabricCLIError) as exc_info:
-        get_connection_config_from_params(
-            payload, con_type, con_type_def, params)
+        get_connection_config_from_params(payload, con_type, con_type_def, params)
 
     assert "Parameters are required for the connection creation method" in str(
-        exc_info.value.message)
+        exc_info.value.message
+    )
     assert "server, database" in str(exc_info.value.message)
 
 
 def test_workspace_identity_with_unsupported_params_ignored_success():
     """Test that WorkspaceIdentity ignores unsupported credential parameters with warning."""
     # Arrange
-    payload = {
-        "displayName": "test-connection",
-        "connectivityType": "ShareableCloud"
-    }
+    payload = {"displayName": "test-connection", "connectivityType": "ShareableCloud"}
 
     con_type = "FabricDataPipelines"
     con_type_def = {
         "type": "FabricDataPipelines",
-        "creationMethods": [
-            {
-                "name": "FabricDataPipelines.Actions",
-                "parameters": []
-            }
-        ],
-        "supportedCredentialTypes": ["WorkspaceIdentity"]
+        "creationMethods": [{"name": "FabricDataPipelines.Actions", "parameters": []}],
+        "supportedCredentialTypes": ["WorkspaceIdentity"],
     }
 
     params = {
         "connectiondetails": {
             "type": "FabricDataPipelines",
-            "creationmethod": "FabricDataPipelines.Actions"
+            "creationmethod": "FabricDataPipelines.Actions",
         },
         "credentialdetails": {
             "type": "WorkspaceIdentity",
             "username": "should_be_ignored",  # This should be ignored for WorkspaceIdentity
-            "password": "should_be_ignored"   # This should be ignored for WorkspaceIdentity
-        }
+            "password": "should_be_ignored",  # This should be ignored for WorkspaceIdentity
+        },
     }
 
     # Act
-    with patch('fabric_cli.utils.fab_ui.print_warning') as mock_warning:
+    with patch("fabric_cli.utils.fab_ui.print_warning") as mock_warning:
         result = get_connection_config_from_params(
-            payload, con_type, con_type_def, params)
+            payload, con_type, con_type_def, params
+        )
 
         mock_warning.assert_called_once()
         assert "username" in str(mock_warning.call_args)
         assert "password" in str(mock_warning.call_args)
 
-    assert result["credentialDetails"]["credentials"]["credentialType"] == "WorkspaceIdentity"
+    assert (
+        result["credentialDetails"]["credentials"]["credentialType"]
+        == "WorkspaceIdentity"
+    )
 
 
 class TestFindMpeConnection:
@@ -170,13 +163,19 @@ class TestFindMpeConnection:
         # Mock the session.request response to return 403
         mock_response = Mock()
         mock_response.status_code = 403
-        mock_response.text = '{"error": {"code": "Forbidden", "message": "Access denied"}}'
+        mock_response.text = (
+            '{"error": {"code": "Forbidden", "message": "Access denied"}}'
+        )
         mock_response.headers = {}
 
-        with patch('requests.Session.request') as mock_session_request, \
-                patch('fabric_cli.client.fab_api_utils.get_api_version') as mock_get_api_version, \
-                patch('fabric_cli.core.fab_auth.FabAuth') as mock_fab_auth_class, \
-                patch('fabric_cli.core.fab_context.Context') as mock_fab_context_class:
+        with (
+            patch("requests.Session.request") as mock_session_request,
+            patch(
+                "fabric_cli.client.fab_api_utils.get_api_version"
+            ) as mock_get_api_version,
+            patch("fabric_cli.core.fab_auth.FabAuth") as mock_fab_auth_class,
+            patch("fabric_cli.core.fab_context.Context") as mock_fab_context_class,
+        ):
 
             mock_session_request.return_value = mock_response
             mock_get_api_version.return_value = "2023-11-01"
@@ -193,8 +192,7 @@ class TestFindMpeConnection:
 
             # Act & Assert
             with pytest.raises(FabricCLIError) as exc_info:
-                find_mpe_connection(
-                    mock_managed_private_endpoint, target_resource_id)
+                find_mpe_connection(mock_managed_private_endpoint, target_resource_id)
 
             # Verify the exception details - this tests that do_request properly handles 403
             assert exc_info.value.status_code == fab_constant.ERROR_FORBIDDEN
@@ -213,10 +211,15 @@ class TestFindMpeConnection:
 
             # Verify the call was made with correct method and URL contains expected parts
             call_args = mock_session_request.call_args
-            assert call_args[1]['method'] == 'get' or call_args.kwargs['method'] == 'get'
+            assert (
+                call_args[1]["method"] == "get" or call_args.kwargs["method"] == "get"
+            )
             # The URL should contain the target resource ID and privateEndpointConnections
-            called_url = call_args.args[1] if len(
-                call_args.args) > 1 else call_args.kwargs['url']
+            called_url = (
+                call_args.args[1]
+                if len(call_args.args) > 1
+                else call_args.kwargs["url"]
+            )
             assert "privateEndpointConnections" in called_url
             assert "api-version=2023-11-01" in called_url
 
@@ -329,17 +332,27 @@ class TestSQLDatabaseRestore:
         }
 
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
-        result = add_type_specific_payload(
-            mock_sql_database_item, mock_args, payload)
+        result = add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert "creationPayload" in result
         assert result["creationPayload"]["creationMode"] == "Restore"
         assert result["creationPayload"]["restorePointInTime"] == "2024-01-15T10:30:00Z"
-        assert result["creationPayload"]["sourceDatabaseReference"]["referenceType"] == "ById"
-        assert result["creationPayload"]["sourceDatabaseReference"]["itemId"] == "12345678-1234-1234-1234-123456789abc"
-        assert result["creationPayload"]["sourceDatabaseReference"]["workspaceId"] == "87654321-4321-4321-4321-cba987654321"
+        assert (
+            result["creationPayload"]["sourceDatabaseReference"]["referenceType"]
+            == "ById"
+        )
+        assert (
+            result["creationPayload"]["sourceDatabaseReference"]["itemId"]
+            == "12345678-1234-1234-1234-123456789abc"
+        )
+        assert (
+            result["creationPayload"]["sourceDatabaseReference"]["workspaceId"]
+            == "87654321-4321-4321-4321-cba987654321"
+        )
 
-    def test_restore_mode_with_offset_timestamp_success(self, mock_sql_database_item, mock_args):
+    def test_restore_mode_with_offset_timestamp_success(
+        self, mock_sql_database_item, mock_args
+    ):
         """Test SQLDatabase restore with timezone offset timestamp."""
         mock_args.params = {
             "mode": "restore",
@@ -349,13 +362,17 @@ class TestSQLDatabaseRestore:
         }
 
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
-        result = add_type_specific_payload(
-            mock_sql_database_item, mock_args, payload)
+        result = add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert "creationPayload" in result
-        assert result["creationPayload"]["restorePointInTime"] == "2024-01-15T10:30:00+05:30"
+        assert (
+            result["creationPayload"]["restorePointInTime"]
+            == "2024-01-15T10:30:00+05:30"
+        )
 
-    def test_restore_mode_missing_restore_point_in_time_failure(self, mock_sql_database_item, mock_args):
+    def test_restore_mode_missing_restore_point_in_time_failure(
+        self, mock_sql_database_item, mock_args
+    ):
         """Test SQLDatabase restore fails when restorePointInTime is missing."""
         mock_args.params = {
             "mode": "restore",
@@ -366,13 +383,14 @@ class TestSQLDatabaseRestore:
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
 
         with pytest.raises(FabricCLIError) as exc_info:
-            add_type_specific_payload(
-                mock_sql_database_item, mock_args, payload)
+            add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
         assert "restorePointInTime" in exc_info.value.message
 
-    def test_restore_mode_missing_item_id_failure(self, mock_sql_database_item, mock_args):
+    def test_restore_mode_missing_item_id_failure(
+        self, mock_sql_database_item, mock_args
+    ):
         """Test SQLDatabase restore fails when itemId is missing."""
         mock_args.params = {
             "mode": "restore",
@@ -383,13 +401,14 @@ class TestSQLDatabaseRestore:
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
 
         with pytest.raises(FabricCLIError) as exc_info:
-            add_type_specific_payload(
-                mock_sql_database_item, mock_args, payload)
+            add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
         assert "itemId" in exc_info.value.message
 
-    def test_restore_mode_missing_workspace_id_failure(self, mock_sql_database_item, mock_args):
+    def test_restore_mode_missing_workspace_id_failure(
+        self, mock_sql_database_item, mock_args
+    ):
         """Test SQLDatabase restore fails when workspaceId is missing."""
         mock_args.params = {
             "mode": "restore",
@@ -400,13 +419,14 @@ class TestSQLDatabaseRestore:
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
 
         with pytest.raises(FabricCLIError) as exc_info:
-            add_type_specific_payload(
-                mock_sql_database_item, mock_args, payload)
+            add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
         assert "workspaceId" in exc_info.value.message
 
-    def test_restore_mode_invalid_timestamp_format_failure(self, mock_sql_database_item, mock_args):
+    def test_restore_mode_invalid_timestamp_format_failure(
+        self, mock_sql_database_item, mock_args
+    ):
         """Test SQLDatabase restore fails with invalid timestamp format."""
         mock_args.params = {
             "mode": "restore",
@@ -418,13 +438,14 @@ class TestSQLDatabaseRestore:
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
 
         with pytest.raises(FabricCLIError) as exc_info:
-            add_type_specific_payload(
-                mock_sql_database_item, mock_args, payload)
+            add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
         assert "ISO 8601" in exc_info.value.message
 
-    def test_restore_mode_invalid_item_id_guid_failure(self, mock_sql_database_item, mock_args):
+    def test_restore_mode_invalid_item_id_guid_failure(
+        self, mock_sql_database_item, mock_args
+    ):
         """Test SQLDatabase restore fails with invalid itemId GUID."""
         mock_args.params = {
             "mode": "restore",
@@ -436,13 +457,14 @@ class TestSQLDatabaseRestore:
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
 
         with pytest.raises(FabricCLIError) as exc_info:
-            add_type_specific_payload(
-                mock_sql_database_item, mock_args, payload)
+            add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_GUID
         assert "itemId" in exc_info.value.message
 
-    def test_restore_mode_invalid_workspace_id_guid_failure(self, mock_sql_database_item, mock_args):
+    def test_restore_mode_invalid_workspace_id_guid_failure(
+        self, mock_sql_database_item, mock_args
+    ):
         """Test SQLDatabase restore fails with invalid workspaceId GUID."""
         mock_args.params = {
             "mode": "restore",
@@ -454,8 +476,7 @@ class TestSQLDatabaseRestore:
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
 
         with pytest.raises(FabricCLIError) as exc_info:
-            add_type_specific_payload(
-                mock_sql_database_item, mock_args, payload)
+            add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_GUID
         assert "workspaceId" in exc_info.value.message
@@ -469,8 +490,7 @@ class TestSQLDatabaseRestore:
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
 
         with pytest.raises(FabricCLIError) as exc_info:
-            add_type_specific_payload(
-                mock_sql_database_item, mock_args, payload)
+            add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
         assert "mode" in exc_info.value.message.lower()
@@ -480,13 +500,14 @@ class TestSQLDatabaseRestore:
         mock_args.params = {}
 
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
-        result = add_type_specific_payload(
-            mock_sql_database_item, mock_args, payload)
+        result = add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         # Standard creation should not add creationPayload
         assert "creationPayload" not in result
 
-    def test_restore_mode_case_insensitive_success(self, mock_sql_database_item, mock_args):
+    def test_restore_mode_case_insensitive_success(
+        self, mock_sql_database_item, mock_args
+    ):
         """Test SQLDatabase restore mode is case-insensitive."""
         mock_args.params = {
             "mode": "RESTORE",
@@ -496,8 +517,7 @@ class TestSQLDatabaseRestore:
         }
 
         payload = {"displayName": "test-db", "type": "SQLDatabase"}
-        result = add_type_specific_payload(
-            mock_sql_database_item, mock_args, payload)
+        result = add_type_specific_payload(mock_sql_database_item, mock_args, payload)
 
         assert "creationPayload" in result
 

--- a/tests/test_utils/test_fab_cmd_mkdir_utils.py
+++ b/tests/test_utils/test_fab_cmd_mkdir_utils.py
@@ -1,16 +1,24 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+
+from argparse import Namespace
 from unittest.mock import Mock, patch
 
 import pytest
 
 from fabric_cli.core import fab_constant
 from fabric_cli.core.fab_exceptions import FabricCLIError
+from fabric_cli.core.fab_types import ItemType
+from fabric_cli.core.hiearchy.fab_hiearchy import Item, Workspace
 from fabric_cli.errors import ErrorMessages
 from fabric_cli.utils.fab_cmd_mkdir_utils import (
+    add_type_specific_payload,
     find_mpe_connection,
     get_connection_config_from_params,
+    get_params_per_item_type,
+    is_valid_guid,
+    is_valid_iso8601_timestamp,
 )
 
 
@@ -21,7 +29,7 @@ def test_fabric_data_pipelines_workspace_identity_no_params_success():
         "displayName": "test-connection",
         "connectivityType": "ShareableCloud"
     }
-    
+
     con_type = "FabricDataPipelines"
     con_type_def = {
         "type": "FabricDataPipelines",
@@ -33,7 +41,7 @@ def test_fabric_data_pipelines_workspace_identity_no_params_success():
         ],
         "supportedCredentialTypes": ["WorkspaceIdentity"]
     }
-    
+
     params = {
         "connectiondetails": {
             "type": "FabricDataPipelines",
@@ -45,9 +53,10 @@ def test_fabric_data_pipelines_workspace_identity_no_params_success():
             # No credential parameters provided since WorkspaceIdentity doesn't require any
         }
     }
-    
-    result = get_connection_config_from_params(payload, con_type, con_type_def, params)
-    
+
+    result = get_connection_config_from_params(
+        payload, con_type, con_type_def, params)
+
     # Assert
     assert result["privacyLevel"] == "None"
     assert result["connectionDetails"]["type"] == "FabricDataPipelines"
@@ -64,7 +73,7 @@ def test_connection_with_required_params_missing_failure():
         "displayName": "test-connection",
         "connectivityType": "ShareableCloud"
     }
-    
+
     con_type = "SQL"
     con_type_def = {
         "type": "SQL",
@@ -79,7 +88,7 @@ def test_connection_with_required_params_missing_failure():
         ],
         "supportedCredentialTypes": ["Basic"]
     }
-    
+
     params = {
         "connectiondetails": {
             "type": "SQL",
@@ -92,11 +101,13 @@ def test_connection_with_required_params_missing_failure():
             "password": "testpass"
         }
     }
-    
+
     with pytest.raises(FabricCLIError) as exc_info:
-        get_connection_config_from_params(payload, con_type, con_type_def, params)
-    
-    assert "Parameters are required for the connection creation method" in str(exc_info.value.message)
+        get_connection_config_from_params(
+            payload, con_type, con_type_def, params)
+
+    assert "Parameters are required for the connection creation method" in str(
+        exc_info.value.message)
     assert "server, database" in str(exc_info.value.message)
 
 
@@ -107,7 +118,7 @@ def test_workspace_identity_with_unsupported_params_ignored_success():
         "displayName": "test-connection",
         "connectivityType": "ShareableCloud"
     }
-    
+
     con_type = "FabricDataPipelines"
     con_type_def = {
         "type": "FabricDataPipelines",
@@ -119,7 +130,7 @@ def test_workspace_identity_with_unsupported_params_ignored_success():
         ],
         "supportedCredentialTypes": ["WorkspaceIdentity"]
     }
-    
+
     params = {
         "connectiondetails": {
             "type": "FabricDataPipelines",
@@ -131,77 +142,383 @@ def test_workspace_identity_with_unsupported_params_ignored_success():
             "password": "should_be_ignored"   # This should be ignored for WorkspaceIdentity
         }
     }
-    
+
     # Act
     with patch('fabric_cli.utils.fab_ui.print_warning') as mock_warning:
-        result = get_connection_config_from_params(payload, con_type, con_type_def, params)
-        
+        result = get_connection_config_from_params(
+            payload, con_type, con_type_def, params)
+
         mock_warning.assert_called_once()
         assert "username" in str(mock_warning.call_args)
         assert "password" in str(mock_warning.call_args)
-    
+
     assert result["credentialDetails"]["credentials"]["credentialType"] == "WorkspaceIdentity"
 
 
 class TestFindMpeConnection:
     """Test cases for find_mpe_connection function."""
-    
+
     def test_find_mpe_connection_return_403_success(self):
         """Test that find_mpe_connection handles 403 forbidden error correctly when session.request returns 403."""
         # Arrange
         mock_managed_private_endpoint = Mock()
         mock_managed_private_endpoint.workspace.id = "test-workspace-id"
         mock_managed_private_endpoint.short_name = "test-mpe-name"
-        
+
         target_resource_id = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Sql/servers/test-server"
-        
+
         # Mock the session.request response to return 403
         mock_response = Mock()
         mock_response.status_code = 403
         mock_response.text = '{"error": {"code": "Forbidden", "message": "Access denied"}}'
         mock_response.headers = {}
-        
+
         with patch('requests.Session.request') as mock_session_request, \
-             patch('fabric_cli.client.fab_api_utils.get_api_version') as mock_get_api_version, \
-             patch('fabric_cli.core.fab_auth.FabAuth') as mock_fab_auth_class, \
-             patch('fabric_cli.core.fab_context.Context') as mock_fab_context_class:
-            
+                patch('fabric_cli.client.fab_api_utils.get_api_version') as mock_get_api_version, \
+                patch('fabric_cli.core.fab_auth.FabAuth') as mock_fab_auth_class, \
+                patch('fabric_cli.core.fab_context.Context') as mock_fab_context_class:
+
             mock_session_request.return_value = mock_response
             mock_get_api_version.return_value = "2023-11-01"
-            
+
             # Mock FabAuth().get_access_token(scope)
             mock_fab_auth_instance = Mock()
             mock_fab_auth_instance.get_access_token.return_value = "mock-access-token"
             mock_fab_auth_class.return_value = mock_fab_auth_instance
-            
+
             # Mock FabContext().command
             mock_fab_context_instance = Mock()
             mock_fab_context_instance.command = "test-command"
             mock_fab_context_class.return_value = mock_fab_context_instance
-            
+
             # Act & Assert
             with pytest.raises(FabricCLIError) as exc_info:
-                find_mpe_connection(mock_managed_private_endpoint, target_resource_id)
-            
+                find_mpe_connection(
+                    mock_managed_private_endpoint, target_resource_id)
+
             # Verify the exception details - this tests that do_request properly handles 403
             assert exc_info.value.status_code == fab_constant.ERROR_FORBIDDEN
             assert exc_info.value.message == ErrorMessages.Common.forbidden()
-            
+
             # Verify session.request was called
             mock_session_request.assert_called_once()
-            
+
             # Verify get_api_version was called with the target resource ID
             mock_get_api_version.assert_called_once_with(target_resource_id)
-            
+
             # Verify authentication and context calls
             mock_fab_auth_class.assert_called_once()
             mock_fab_auth_instance.get_access_token.assert_called_once()
             mock_fab_context_class.assert_called_once()
-            
+
             # Verify the call was made with correct method and URL contains expected parts
             call_args = mock_session_request.call_args
             assert call_args[1]['method'] == 'get' or call_args.kwargs['method'] == 'get'
             # The URL should contain the target resource ID and privateEndpointConnections
-            called_url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs['url']
+            called_url = call_args.args[1] if len(
+                call_args.args) > 1 else call_args.kwargs['url']
             assert "privateEndpointConnections" in called_url
             assert "api-version=2023-11-01" in called_url
+
+
+class TestIsValidGuid:
+    """Test cases for is_valid_guid function."""
+
+    def test_valid_guid_lowercase(self):
+        """Test valid GUID with lowercase letters."""
+        assert is_valid_guid("12345678-1234-1234-1234-123456789abc")
+
+    def test_valid_guid_uppercase(self):
+        """Test valid GUID with uppercase letters."""
+        assert is_valid_guid("12345678-1234-1234-1234-123456789ABC")
+
+    def test_valid_guid_mixed_case(self):
+        """Test valid GUID with mixed case letters."""
+        assert is_valid_guid("12345678-abcd-ABCD-1234-123456789AbC")
+
+    def test_invalid_guid_wrong_format(self):
+        """Test invalid GUID with wrong format."""
+        assert not is_valid_guid("not-a-guid")
+
+    def test_invalid_guid_missing_hyphens(self):
+        """Test invalid GUID with missing hyphens."""
+        assert not is_valid_guid("1234567812341234123412345678abc")
+
+    def test_invalid_guid_extra_characters(self):
+        """Test invalid GUID with extra characters."""
+        assert not is_valid_guid("12345678-1234-1234-1234-123456789abcd")
+
+    def test_invalid_guid_empty_string(self):
+        """Test empty string is not a valid GUID."""
+        assert not is_valid_guid("")
+
+
+class TestIsValidIso8601Timestamp:
+    """Test cases for is_valid_iso8601_timestamp function."""
+
+    def test_valid_timestamp_utc_z_suffix(self):
+        """Test valid ISO 8601 timestamp with Z suffix."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00Z")
+
+    def test_valid_timestamp_with_milliseconds(self):
+        """Test valid ISO 8601 timestamp with milliseconds."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00.123Z")
+
+    def test_valid_timestamp_with_microseconds(self):
+        """Test valid ISO 8601 timestamp with microseconds."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00.123456Z")
+
+    def test_valid_timestamp_positive_offset(self):
+        """Test valid ISO 8601 timestamp with positive timezone offset."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00+05:30")
+
+    def test_valid_timestamp_negative_offset(self):
+        """Test valid ISO 8601 timestamp with negative timezone offset."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00-08:00")
+
+    def test_valid_timestamp_zero_offset(self):
+        """Test valid ISO 8601 timestamp with zero offset."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00+00:00")
+
+    def test_invalid_timestamp_no_timezone(self):
+        """Test timestamp without timezone is invalid."""
+        assert not is_valid_iso8601_timestamp("2024-01-15T10:30:00")
+
+    def test_invalid_timestamp_date_only(self):
+        """Test date-only string is invalid."""
+        assert not is_valid_iso8601_timestamp("2024-01-15")
+
+    def test_invalid_timestamp_wrong_format(self):
+        """Test invalid timestamp format."""
+        assert not is_valid_iso8601_timestamp("not-a-timestamp")
+
+    def test_invalid_timestamp_empty_string(self):
+        """Test empty string is not a valid timestamp."""
+        assert not is_valid_iso8601_timestamp("")
+
+
+class TestSQLDatabaseRestore:
+    """Test cases for SQLDatabase point-in-time restore functionality."""
+
+    @pytest.fixture
+    def mock_sql_database_item(self):
+        """Create a mock SQL database item."""
+        mock_workspace = Mock(spec=Workspace)
+        mock_workspace.id = "workspace-id-123"
+
+        item = Mock(spec=Item)
+        item.item_type = ItemType.SQL_DATABASE
+        item.workspace = mock_workspace
+        item.short_name = "test-db"
+        return item
+
+    @pytest.fixture
+    def mock_args(self):
+        """Create mock args namespace."""
+        args = Namespace()
+        args.params = {}
+        return args
+
+    def test_restore_mode_valid_params_success(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore with valid parameters."""
+        mock_args.params = {
+            "mode": "restore",
+            "restorepointintime": "2024-01-15T10:30:00Z",
+            "itemid": "12345678-1234-1234-1234-123456789abc",
+            "workspaceid": "87654321-4321-4321-4321-cba987654321",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+        result = add_type_specific_payload(
+            mock_sql_database_item, mock_args, payload)
+
+        assert "creationPayload" in result
+        assert result["creationPayload"]["creationMode"] == "Restore"
+        assert result["creationPayload"]["restorePointInTime"] == "2024-01-15T10:30:00Z"
+        assert result["creationPayload"]["sourceDatabaseReference"]["referenceType"] == "ById"
+        assert result["creationPayload"]["sourceDatabaseReference"]["itemId"] == "12345678-1234-1234-1234-123456789abc"
+        assert result["creationPayload"]["sourceDatabaseReference"]["workspaceId"] == "87654321-4321-4321-4321-cba987654321"
+
+    def test_restore_mode_with_offset_timestamp_success(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore with timezone offset timestamp."""
+        mock_args.params = {
+            "mode": "restore",
+            "restorepointintime": "2024-01-15T10:30:00+05:30",
+            "itemid": "12345678-1234-1234-1234-123456789abc",
+            "workspaceid": "87654321-4321-4321-4321-cba987654321",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+        result = add_type_specific_payload(
+            mock_sql_database_item, mock_args, payload)
+
+        assert "creationPayload" in result
+        assert result["creationPayload"]["restorePointInTime"] == "2024-01-15T10:30:00+05:30"
+
+    def test_restore_mode_missing_restore_point_in_time_failure(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore fails when restorePointInTime is missing."""
+        mock_args.params = {
+            "mode": "restore",
+            "itemid": "12345678-1234-1234-1234-123456789abc",
+            "workspaceid": "87654321-4321-4321-4321-cba987654321",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            add_type_specific_payload(
+                mock_sql_database_item, mock_args, payload)
+
+        assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+        assert "restorePointInTime" in exc_info.value.message
+
+    def test_restore_mode_missing_item_id_failure(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore fails when itemId is missing."""
+        mock_args.params = {
+            "mode": "restore",
+            "restorepointintime": "2024-01-15T10:30:00Z",
+            "workspaceid": "87654321-4321-4321-4321-cba987654321",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            add_type_specific_payload(
+                mock_sql_database_item, mock_args, payload)
+
+        assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+        assert "itemId" in exc_info.value.message
+
+    def test_restore_mode_missing_workspace_id_failure(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore fails when workspaceId is missing."""
+        mock_args.params = {
+            "mode": "restore",
+            "restorepointintime": "2024-01-15T10:30:00Z",
+            "itemid": "12345678-1234-1234-1234-123456789abc",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            add_type_specific_payload(
+                mock_sql_database_item, mock_args, payload)
+
+        assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+        assert "workspaceId" in exc_info.value.message
+
+    def test_restore_mode_invalid_timestamp_format_failure(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore fails with invalid timestamp format."""
+        mock_args.params = {
+            "mode": "restore",
+            "restorepointintime": "2024-01-15T10:30:00",  # Missing timezone
+            "itemid": "12345678-1234-1234-1234-123456789abc",
+            "workspaceid": "87654321-4321-4321-4321-cba987654321",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            add_type_specific_payload(
+                mock_sql_database_item, mock_args, payload)
+
+        assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+        assert "ISO 8601" in exc_info.value.message
+
+    def test_restore_mode_invalid_item_id_guid_failure(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore fails with invalid itemId GUID."""
+        mock_args.params = {
+            "mode": "restore",
+            "restorepointintime": "2024-01-15T10:30:00Z",
+            "itemid": "not-a-valid-guid",
+            "workspaceid": "87654321-4321-4321-4321-cba987654321",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            add_type_specific_payload(
+                mock_sql_database_item, mock_args, payload)
+
+        assert exc_info.value.status_code == fab_constant.ERROR_INVALID_GUID
+        assert "itemId" in exc_info.value.message
+
+    def test_restore_mode_invalid_workspace_id_guid_failure(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore fails with invalid workspaceId GUID."""
+        mock_args.params = {
+            "mode": "restore",
+            "restorepointintime": "2024-01-15T10:30:00Z",
+            "itemid": "12345678-1234-1234-1234-123456789abc",
+            "workspaceid": "not-a-valid-guid",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            add_type_specific_payload(
+                mock_sql_database_item, mock_args, payload)
+
+        assert exc_info.value.status_code == fab_constant.ERROR_INVALID_GUID
+        assert "workspaceId" in exc_info.value.message
+
+    def test_invalid_mode_failure(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase creation fails with invalid mode."""
+        mock_args.params = {
+            "mode": "invalid",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            add_type_specific_payload(
+                mock_sql_database_item, mock_args, payload)
+
+        assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+        assert "mode" in exc_info.value.message.lower()
+
+    def test_standard_creation_no_mode_success(self, mock_sql_database_item, mock_args):
+        """Test standard SQLDatabase creation without mode parameter."""
+        mock_args.params = {}
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+        result = add_type_specific_payload(
+            mock_sql_database_item, mock_args, payload)
+
+        # Standard creation should not add creationPayload
+        assert "creationPayload" not in result
+
+    def test_restore_mode_case_insensitive_success(self, mock_sql_database_item, mock_args):
+        """Test SQLDatabase restore mode is case-insensitive."""
+        mock_args.params = {
+            "mode": "RESTORE",
+            "restorepointintime": "2024-01-15T10:30:00Z",
+            "itemid": "12345678-1234-1234-1234-123456789abc",
+            "workspaceid": "87654321-4321-4321-4321-cba987654321",
+        }
+
+        payload = {"displayName": "test-db", "type": "SQLDatabase"}
+        result = add_type_specific_payload(
+            mock_sql_database_item, mock_args, payload)
+
+        assert "creationPayload" in result
+
+
+class TestGetParamsPerItemTypeSQLDatabase:
+    """Test cases for get_params_per_item_type for SQLDatabase."""
+
+    @pytest.fixture
+    def mock_sql_database_item(self):
+        """Create a mock SQL database item."""
+        item = Mock(spec=Item)
+        item.item_type = ItemType.SQL_DATABASE
+        return item
+
+    def test_sql_database_params(self, mock_sql_database_item):
+        """Test that SQL Database returns correct optional parameters."""
+        required, optional = get_params_per_item_type(mock_sql_database_item)
+
+        assert required == []
+        assert len(optional) == 4
+        assert any("mode" in param for param in optional)
+        assert any("restorePointInTime" in param for param in optional)
+        assert any("itemId" in param for param in optional)
+        assert any("workspaceId" in param for param in optional)

--- a/tests/test_utils/test_fab_cmd_mkdir_utils.py
+++ b/tests/test_utils/test_fab_cmd_mkdir_utils.py
@@ -18,7 +18,6 @@ from fabric_cli.utils.fab_cmd_mkdir_utils import (
     get_connection_config_from_params,
     get_params_per_item_type,
 )
-from fabric_cli.utils.fab_util import is_valid_guid, is_valid_iso8601_timestamp
 
 
 def test_fabric_data_pipelines_workspace_identity_no_params_success():
@@ -222,82 +221,6 @@ class TestFindMpeConnection:
             )
             assert "privateEndpointConnections" in called_url
             assert "api-version=2023-11-01" in called_url
-
-
-class TestIsValidGuid:
-    """Test cases for is_valid_guid function."""
-
-    def test_valid_guid_lowercase(self):
-        """Test valid GUID with lowercase letters."""
-        assert is_valid_guid("12345678-1234-1234-1234-123456789abc")
-
-    def test_valid_guid_uppercase(self):
-        """Test valid GUID with uppercase letters."""
-        assert is_valid_guid("12345678-1234-1234-1234-123456789ABC")
-
-    def test_valid_guid_mixed_case(self):
-        """Test valid GUID with mixed case letters."""
-        assert is_valid_guid("12345678-abcd-ABCD-1234-123456789AbC")
-
-    def test_invalid_guid_wrong_format(self):
-        """Test invalid GUID with wrong format."""
-        assert not is_valid_guid("not-a-guid")
-
-    def test_invalid_guid_missing_hyphens(self):
-        """Test invalid GUID with missing hyphens."""
-        assert not is_valid_guid("1234567812341234123412345678abc")
-
-    def test_invalid_guid_extra_characters(self):
-        """Test invalid GUID with extra characters."""
-        assert not is_valid_guid("12345678-1234-1234-1234-123456789abcd")
-
-    def test_invalid_guid_empty_string(self):
-        """Test empty string is not a valid GUID."""
-        assert not is_valid_guid("")
-
-
-class TestIsValidIso8601Timestamp:
-    """Test cases for is_valid_iso8601_timestamp function."""
-
-    def test_valid_timestamp_utc_z_suffix(self):
-        """Test valid ISO 8601 timestamp with Z suffix."""
-        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00Z")
-
-    def test_valid_timestamp_with_milliseconds(self):
-        """Test valid ISO 8601 timestamp with milliseconds."""
-        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00.123Z")
-
-    def test_valid_timestamp_with_microseconds(self):
-        """Test valid ISO 8601 timestamp with microseconds."""
-        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00.123456Z")
-
-    def test_valid_timestamp_positive_offset(self):
-        """Test valid ISO 8601 timestamp with positive timezone offset."""
-        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00+05:30")
-
-    def test_valid_timestamp_negative_offset(self):
-        """Test valid ISO 8601 timestamp with negative timezone offset."""
-        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00-08:00")
-
-    def test_valid_timestamp_zero_offset(self):
-        """Test valid ISO 8601 timestamp with zero offset."""
-        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00+00:00")
-
-    def test_invalid_timestamp_no_timezone(self):
-        """Test timestamp without timezone is invalid."""
-        assert not is_valid_iso8601_timestamp("2024-01-15T10:30:00")
-
-    def test_invalid_timestamp_date_only(self):
-        """Test date-only string is invalid."""
-        assert not is_valid_iso8601_timestamp("2024-01-15")
-
-    def test_invalid_timestamp_wrong_format(self):
-        """Test invalid timestamp format."""
-        assert not is_valid_iso8601_timestamp("not-a-timestamp")
-
-    def test_invalid_timestamp_empty_string(self):
-        """Test empty string is not a valid timestamp."""
-        assert not is_valid_iso8601_timestamp("")
 
 
 class TestSQLDatabaseRestore:

--- a/tests/test_utils/test_fab_cmd_mkdir_utils.py
+++ b/tests/test_utils/test_fab_cmd_mkdir_utils.py
@@ -215,8 +215,7 @@ class TestFindMpeConnection:
             call_args = mock_session_request.call_args
             assert call_args[1]['method'] == 'get' or call_args.kwargs['method'] == 'get'
             # The URL should contain the target resource ID and privateEndpointConnections
-            called_url = call_args.args[1] if len(
-                call_args.args) > 1 else call_args.kwargs['url']
+            called_url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs['url']
             assert "privateEndpointConnections" in called_url
             assert "api-version=2023-11-01" in called_url
 

--- a/tests/test_utils/test_fab_cmd_mkdir_utils.py
+++ b/tests/test_utils/test_fab_cmd_mkdir_utils.py
@@ -215,7 +215,8 @@ class TestFindMpeConnection:
             call_args = mock_session_request.call_args
             assert call_args[1]['method'] == 'get' or call_args.kwargs['method'] == 'get'
             # The URL should contain the target resource ID and privateEndpointConnections
-            called_url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs['url']
+            called_url = call_args.args[1] if len(
+                call_args.args) > 1 else call_args.kwargs['url']
             assert "privateEndpointConnections" in called_url
             assert "api-version=2023-11-01" in called_url
 
@@ -369,7 +370,7 @@ class TestSQLDatabaseRestore:
                 mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-        assert "restorePointInTime" in exc_info.value.message
+        assert "restorepointintime" in exc_info.value.message
 
     def test_restore_mode_missing_item_id_failure(self, mock_sql_database_item, mock_args):
         """Test SQLDatabase restore fails when itemId is missing."""
@@ -386,7 +387,7 @@ class TestSQLDatabaseRestore:
                 mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-        assert "itemId" in exc_info.value.message
+        assert "itemid" in exc_info.value.message
 
     def test_restore_mode_missing_workspace_id_failure(self, mock_sql_database_item, mock_args):
         """Test SQLDatabase restore fails when workspaceId is missing."""
@@ -403,7 +404,7 @@ class TestSQLDatabaseRestore:
                 mock_sql_database_item, mock_args, payload)
 
         assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-        assert "workspaceId" in exc_info.value.message
+        assert "workspaceid" in exc_info.value.message
 
     def test_restore_mode_invalid_timestamp_format_failure(self, mock_sql_database_item, mock_args):
         """Test SQLDatabase restore fails with invalid timestamp format."""

--- a/tests/test_utils/test_fab_util.py
+++ b/tests/test_utils/test_fab_util.py
@@ -8,6 +8,7 @@ import pytest
 
 import fabric_cli.utils.fab_util as utils
 from fabric_cli.core import fab_constant, fab_state_config
+from fabric_cli.utils.fab_util import is_valid_guid, is_valid_iso8601_timestamp
 
 
 def test_dumps():
@@ -16,32 +17,34 @@ def test_dumps():
     data = {"key": "value", "number": 42}
     result = utils.dumps(data)
     assert result == '{"key": "value", "number": 42}'
-    
+
     # Test with indentation
     result = utils.dumps(data, indent=2)
     expected = '{\n  "key": "value",\n  "number": 42\n}'
     assert result == expected
-    
+
     # Test bytes redaction
     data_with_bytes = {"key": "value", "bytes_data": b"secret"}
     result = utils.dumps(data_with_bytes)
     assert '"__REDACTED__bytes__"' in result
-    assert 'secret' not in result
-    
+    assert "secret" not in result
+
     # Test bytearray redaction
     data_with_bytearray = {"key": "value", "bytearray_data": bytearray(b"secret")}
     result = utils.dumps(data_with_bytearray)
     assert '"__REDACTED__bytes__"' in result
-    assert 'secret' not in result
-    
+    assert "secret" not in result
+
     # Test non-serializable object raises TypeError
     class NonSerializable:
         pass
-    
+
     data_with_non_serializable = {"key": "value", "obj": NonSerializable()}
     with pytest.raises(TypeError) as excinfo:
         utils.dumps(data_with_non_serializable)
-    assert "Object of type NonSerializable is not JSON serializable" in str(excinfo.value)
+    assert "Object of type NonSerializable is not JSON serializable" in str(
+        excinfo.value
+    )
 
 
 def test_process_nargs():
@@ -74,8 +77,6 @@ def test_remove_dotshortcut_from_path_for_onelake():
     path = "path"
     result = utils.remove_dot_suffix(path)
     assert result == "path"
-
-
 
 
 def test_get_dict_from_params():
@@ -142,31 +143,32 @@ def test_get_dict_from_params():
     params = "key1=value1, key2=value2, key3=value3"
     result = utils.get_dict_from_params(params)
     assert result == {"key1": "value1", "key2": "value2", "key3": "value3"}
-    
+
     # Test multiple spaces after comma
     params = "key1=value1,  key2=value2,   key3=value3"
     result = utils.get_dict_from_params(params)
     assert result == {"key1": "value1", "key2": "value2", "key3": "value3"}
-    
+
     # Test mixed spacing (some with spaces, some without)
     params = "key1=value1,key2=value2, key3=value3,  key4=value4"
     result = utils.get_dict_from_params(params)
-    assert result == {"key1": "value1", "key2": "value2", "key3": "value3", "key4": "value4"}
-    
+    assert result == {
+        "key1": "value1",
+        "key2": "value2",
+        "key3": "value3",
+        "key4": "value4",
+    }
+
     # Test with nested keys and spaces
     params = "key1.sub1=value1, key1.sub2=value2, key2=value3"
     result = utils.get_dict_from_params(params)
     assert result == {"key1": {"sub1": "value1", "sub2": "value2"}, "key2": "value3"}
-    
+
     # Test with complex values and spaces
     params = 'key1={"nested": "value"}, key2=[1,2,3], key3=simple'
     result = utils.get_dict_from_params(params)
-    assert result == {
-        "key1": '{nested: value}',
-        "key2": "[1,2,3]",
-        "key3": "simple"
-    }
-    
+    assert result == {"key1": "{nested: value}", "key2": "[1,2,3]", "key3": "simple"}
+
     # Test tabs and mixed whitespace after comma
     params = "key1=value1,\tkey2=value2,\n key3=value3"
     result = utils.get_dict_from_params(params)
@@ -243,9 +245,6 @@ def test_remove_keys_from_dict():
     keys = ["key3"]
     result = utils.remove_keys_from_dict(_dict, keys)
     assert result == _dict
-
-
-
 
 
 def test_get_os_specific_command(monkeypatch):
@@ -329,4 +328,77 @@ def test_get_capacity_settings(monkeypatch):
     assert result == ("new_admin", "new_loc", "new_sub_id", "new_rg", "F2")
 
 
+class TestIsValidGuid:
+    """Test cases for is_valid_guid function."""
 
+    def test_valid_guid_lowercase(self):
+        """Test valid GUID with lowercase letters."""
+        assert is_valid_guid("12345678-1234-1234-1234-123456789abc")
+
+    def test_valid_guid_uppercase(self):
+        """Test valid GUID with uppercase letters."""
+        assert is_valid_guid("12345678-1234-1234-1234-123456789ABC")
+
+    def test_valid_guid_mixed_case(self):
+        """Test valid GUID with mixed case letters."""
+        assert is_valid_guid("12345678-abcd-ABCD-1234-123456789AbC")
+
+    def test_invalid_guid_wrong_format(self):
+        """Test invalid GUID with wrong format."""
+        assert not is_valid_guid("not-a-guid")
+
+    def test_invalid_guid_missing_hyphens(self):
+        """Test invalid GUID with missing hyphens."""
+        assert not is_valid_guid("1234567812341234123412345678abc")
+
+    def test_invalid_guid_extra_characters(self):
+        """Test invalid GUID with extra characters."""
+        assert not is_valid_guid("12345678-1234-1234-1234-123456789abcd")
+
+    def test_invalid_guid_empty_string(self):
+        """Test empty string is not a valid GUID."""
+        assert not is_valid_guid("")
+
+
+class TestIsValidIso8601Timestamp:
+    """Test cases for is_valid_iso8601_timestamp function."""
+
+    def test_valid_timestamp_utc_z_suffix(self):
+        """Test valid ISO 8601 timestamp with Z suffix."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00Z")
+
+    def test_valid_timestamp_with_milliseconds(self):
+        """Test valid ISO 8601 timestamp with milliseconds."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00.123Z")
+
+    def test_valid_timestamp_with_microseconds(self):
+        """Test valid ISO 8601 timestamp with microseconds."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00.123456Z")
+
+    def test_valid_timestamp_positive_offset(self):
+        """Test valid ISO 8601 timestamp with positive timezone offset."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00+05:30")
+
+    def test_valid_timestamp_negative_offset(self):
+        """Test valid ISO 8601 timestamp with negative timezone offset."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00-08:00")
+
+    def test_valid_timestamp_zero_offset(self):
+        """Test valid ISO 8601 timestamp with zero offset."""
+        assert is_valid_iso8601_timestamp("2024-01-15T10:30:00+00:00")
+
+    def test_invalid_timestamp_no_timezone(self):
+        """Test timestamp without timezone is invalid."""
+        assert not is_valid_iso8601_timestamp("2024-01-15T10:30:00")
+
+    def test_invalid_timestamp_date_only(self):
+        """Test date-only string is invalid."""
+        assert not is_valid_iso8601_timestamp("2024-01-15")
+
+    def test_invalid_timestamp_wrong_format(self):
+        """Test invalid timestamp format."""
+        assert not is_valid_iso8601_timestamp("not-a-timestamp")
+
+    def test_invalid_timestamp_empty_string(self):
+        """Test empty string is not a valid timestamp."""
+        assert not is_valid_iso8601_timestamp("")


### PR DESCRIPTION
Fixes #149.
Validates the point-in-time restore property of SQL databases by ensuring the provided GUIDs and timestamps match the proper regex.