### PR TITLE
refactor: validate backup retention days on SQL DB

### DIFF
--- a/.changes/unreleased/optimization-20260617-052412.yaml
+++ b/.changes/unreleased/optimization-20260617-052412.yaml
@@ -1,0 +1,6 @@
+kind: optimization
+body: Adds validation for backup retention days on SQL DB
+time: 2026-06-17T05:24:12.568818136Z
+custom:
+    Author: v-alexmoraru
+    AuthorLink: https://github.com/v-alexmoraru

--- a/src/fabric_cli/commands/fs/set/fab_fs_set_item.py
+++ b/src/fabric_cli/commands/fs/set/fab_fs_set_item.py
@@ -8,7 +8,11 @@ from fabric_cli.client import fab_api_item as item_api
 from fabric_cli.core import fab_constant
 from fabric_cli.core.fab_commands import Command
 from fabric_cli.core.fab_exceptions import FabricCLIError
-from fabric_cli.core.fab_types import definition_format_mapping, format_mapping
+from fabric_cli.core.fab_types import (
+    ItemType,
+    definition_format_mapping,
+    format_mapping,
+)
 from fabric_cli.core.hiearchy.fab_hiearchy import Item
 from fabric_cli.errors.common import CommonErrors
 from fabric_cli.utils import fab_cmd_set_utils as utils_set
@@ -23,6 +27,10 @@ def exec(item: Item, args: Namespace) -> None:
     query_value = item.extract_friendly_name_path_or_default(query)
 
     utils_set.validate_item_query(query_value, item)
+
+    # Validate SQLDatabase-specific properties
+    if item.item_type == ItemType.SQL_DATABASE:
+        utils_set.validate_sql_database_property(query_value, args.input)
 
     utils_set.print_set_warning()
     if force or utils_ui.prompt_confirm():

--- a/src/fabric_cli/core/fab_constant.py
+++ b/src/fabric_cli/core/fab_constant.py
@@ -353,6 +353,8 @@ ITEM_SET_ALLOWED_METADATA_KEYS = [
 SET_COMMAND_INVALID_QUERIES = ["id", "type", "workspaceId", "folderId"]
 
 # SQLDatabase property validation
-SQL_DATABASE_BACKUP_RETENTION_MIN_DAYS = 1
-SQL_DATABASE_BACKUP_RETENTION_MAX_DAYS = 35
-SQL_DATABASE_BACKUP_RETENTION_PROPERTY = "properties.backupRetentionDays"
+SQL_DATABASE_BACKUP_RETENTION = {
+    "property": "properties.backupRetentionDays",
+    "min_days": 1,
+    "max_days": 35,
+}

--- a/src/fabric_cli/core/fab_constant.py
+++ b/src/fabric_cli/core/fab_constant.py
@@ -352,3 +352,7 @@ ITEM_SET_ALLOWED_METADATA_KEYS = [
 # Invalid query parameters for set command across all fabric resources
 SET_COMMAND_INVALID_QUERIES = ["id", "type", "workspaceId", "folderId"]
 
+# SQLDatabase property validation
+SQL_DATABASE_BACKUP_RETENTION_MIN_DAYS = 1
+SQL_DATABASE_BACKUP_RETENTION_MAX_DAYS = 35
+SQL_DATABASE_BACKUP_RETENTION_PROPERTY = "properties.backupRetentionDays"

--- a/src/fabric_cli/errors/common.py
+++ b/src/fabric_cli/errors/common.py
@@ -268,6 +268,6 @@ class CommonErrors:
     @staticmethod
     def invalid_backup_retention_days(value: str, min_days: int, max_days: int) -> str:
         return (
-            f"Invalid backupRetentionDays value '{value}'. "
+            f"Invalid backup retention days value '{value}'. "
             f"Must be an integer between {min_days} and {max_days} days."
         )

--- a/src/fabric_cli/errors/common.py
+++ b/src/fabric_cli/errors/common.py
@@ -264,3 +264,10 @@ class CommonErrors:
     @staticmethod
     def invalid_parameter_format(param: str) -> str:
         return f"Invalid parameter format: '{param}'. Use key=value or key!=value."
+
+    @staticmethod
+    def invalid_backup_retention_days(value: str, min_days: int, max_days: int) -> str:
+        return (
+            f"Invalid backupRetentionDays value '{value}'. "
+            f"Must be an integer between {min_days} and {max_days} days."
+        )

--- a/src/fabric_cli/utils/fab_cmd_set_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_set_utils.py
@@ -92,6 +92,45 @@ def validate_query_not_in_blocklist(
             )
 
 
+def validate_sql_database_property(query: str, input_value: str) -> None:
+    """Validate SQLDatabase-specific property values.
+
+    Args:
+        query: The property query path being set.
+        input_value: The input value to validate.
+
+    Raises:
+        FabricCLIError: If the value is invalid for the property.
+    """
+    if query == fab_constant.SQL_DATABASE_BACKUP_RETENTION_PROPERTY:
+        try:
+            # Try to parse as JSON first (handles numeric input)
+            try:
+                value = json.loads(input_value)
+            except (TypeError, json.JSONDecodeError):
+                value = input_value
+
+            # Ensure it's an integer
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError("Not an integer")
+
+            # Validate range
+            min_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION_MIN_DAYS
+            max_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION_MAX_DAYS
+            if value < min_days or value > max_days:
+                raise ValueError("Out of range")
+
+        except (ValueError, TypeError):
+            raise FabricCLIError(
+                CommonErrors.invalid_backup_retention_days(
+                    str(input_value),
+                    fab_constant.SQL_DATABASE_BACKUP_RETENTION_MIN_DAYS,
+                    fab_constant.SQL_DATABASE_BACKUP_RETENTION_MAX_DAYS,
+                ),
+                fab_constant.ERROR_INVALID_INPUT,
+            )
+
+
 def ensure_notebook_dependency(decoded_item_def: dict, query: str) -> dict:
     dependency_types = ["lakehouse", "warehouse", "environment"]
 

--- a/src/fabric_cli/utils/fab_cmd_set_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_set_utils.py
@@ -102,9 +102,9 @@ def validate_sql_database_property(query: str, input_value: str) -> None:
     Raises:
         FabricCLIError: If the value is invalid for the property.
     """
-    if query == fab_constant.SQL_DATABASE_BACKUP_RETENTION_PROPERTY:
-        min_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION_MIN_DAYS
-        max_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION_MAX_DAYS
+    if query == fab_constant.SQL_DATABASE_BACKUP_RETENTION["property"]:
+        min_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION["min_days"]
+        max_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION["max_days"]
 
         try:
             try:
@@ -112,9 +112,7 @@ def validate_sql_database_property(query: str, input_value: str) -> None:
             except ValueError:
                 # Fall back to JSON for encoded values like '7' or '"7"'
                 parsed = json.loads(input_value)
-                if isinstance(parsed, bool):
-                    raise ValueError("Booleans are not valid integer values")
-                elif isinstance(parsed, int):
+                if isinstance(parsed, int):
                     value = parsed
                 elif isinstance(parsed, str):
                     value = int(parsed)

--- a/src/fabric_cli/utils/fab_cmd_set_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_set_utils.py
@@ -112,7 +112,7 @@ def validate_sql_database_property(query: str, input_value: str) -> None:
             except ValueError:
                 # Fall back to JSON for encoded values like '7' or '"7"'
                 parsed = json.loads(input_value)
-                if isinstance(parsed, int):
+                if type(parsed) is int:
                     value = parsed
                 elif isinstance(parsed, str):
                     value = int(parsed)

--- a/src/fabric_cli/utils/fab_cmd_set_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_set_utils.py
@@ -103,8 +103,8 @@ def validate_sql_database_property(query: str, input_value: str) -> None:
         FabricCLIError: If the value is invalid for the property.
     """
     if query == fab_constant.SQL_DATABASE_BACKUP_RETENTION["property"]:
-        min_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION["min_days"]
-        max_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION["max_days"]
+        min_days: int = fab_constant.SQL_DATABASE_BACKUP_RETENTION["min_days"]  # type: ignore[assignment]
+        max_days: int = fab_constant.SQL_DATABASE_BACKUP_RETENTION["max_days"]  # type: ignore[assignment]
 
         try:
             try:
@@ -236,8 +236,7 @@ def update_cache(
 
 
 def print_set_warning() -> None:
-    fab_logger.log_warning(
-        "Modifying properties may lead to unintended consequences")
+    fab_logger.log_warning("Modifying properties may lead to unintended consequences")
 
 
 def extract_updated_properties(updated_data: dict, query_path: str) -> dict:
@@ -303,8 +302,7 @@ def _decode_payload(item_def: dict) -> dict:
                 payload_base64 = part["payload"]
 
                 if payload_base64:
-                    decoded_payload = base64.b64decode(
-                        payload_base64).decode("utf-8")
+                    decoded_payload = base64.b64decode(payload_base64).decode("utf-8")
                     decoded_payload = json.loads(decoded_payload)
                     # Store the decoded payload
                     part["payload"] = decoded_payload

--- a/src/fabric_cli/utils/fab_cmd_set_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_set_utils.py
@@ -103,31 +103,34 @@ def validate_sql_database_property(query: str, input_value: str) -> None:
         FabricCLIError: If the value is invalid for the property.
     """
     if query == fab_constant.SQL_DATABASE_BACKUP_RETENTION_PROPERTY:
+        min_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION_MIN_DAYS
+        max_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION_MAX_DAYS
+
         try:
-            # Try to parse as JSON first (handles numeric input)
             try:
-                value = json.loads(input_value)
-            except (TypeError, json.JSONDecodeError):
-                value = input_value
-
-            if isinstance(value, str):
-                value = int(value)
-
-            if not isinstance(value, int) or isinstance(value, bool):
-                raise ValueError("Not an integer")
+                value = int(input_value)
+            except ValueError:
+                # Fall back to JSON for encoded values like '7' or '"7"'
+                parsed = json.loads(input_value)
+                if isinstance(parsed, bool):
+                    raise ValueError("Booleans are not valid integer values")
+                elif isinstance(parsed, int):
+                    value = parsed
+                elif isinstance(parsed, str):
+                    value = int(parsed)
+                else:
+                    raise ValueError("Value must be an integer")
 
             # Validate range
-            min_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION_MIN_DAYS
-            max_days = fab_constant.SQL_DATABASE_BACKUP_RETENTION_MAX_DAYS
-            if value < min_days or value > max_days:
+            if not min_days <= value <= max_days:
                 raise ValueError("Out of range")
 
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, json.JSONDecodeError):
             raise FabricCLIError(
                 CommonErrors.invalid_backup_retention_days(
                     str(input_value),
-                    fab_constant.SQL_DATABASE_BACKUP_RETENTION_MIN_DAYS,
-                    fab_constant.SQL_DATABASE_BACKUP_RETENTION_MAX_DAYS,
+                    min_days,
+                    max_days,
                 ),
                 fab_constant.ERROR_INVALID_INPUT,
             )

--- a/src/fabric_cli/utils/fab_cmd_set_utils.py
+++ b/src/fabric_cli/utils/fab_cmd_set_utils.py
@@ -110,7 +110,9 @@ def validate_sql_database_property(query: str, input_value: str) -> None:
             except (TypeError, json.JSONDecodeError):
                 value = input_value
 
-            # Ensure it's an integer
+            if isinstance(value, str):
+                value = int(value)
+
             if not isinstance(value, int) or isinstance(value, bool):
                 raise ValueError("Not an integer")
 
@@ -233,7 +235,8 @@ def update_cache(
 
 
 def print_set_warning() -> None:
-    fab_logger.log_warning("Modifying properties may lead to unintended consequences")
+    fab_logger.log_warning(
+        "Modifying properties may lead to unintended consequences")
 
 
 def extract_updated_properties(updated_data: dict, query_path: str) -> dict:
@@ -299,7 +302,8 @@ def _decode_payload(item_def: dict) -> dict:
                 payload_base64 = part["payload"]
 
                 if payload_base64:
-                    decoded_payload = base64.b64decode(payload_base64).decode("utf-8")
+                    decoded_payload = base64.b64decode(
+                        payload_base64).decode("utf-8")
                     decoded_payload = json.loads(decoded_payload)
                     # Store the decoded payload
                     part["payload"] = decoded_payload

--- a/tests/test_commands/recordings/test_commands/test_set/class_setup.yaml
+++ b/tests/test_commands/recordings/test_commands/test_set/class_setup.yaml
@@ -11,7 +11,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (None; Linux/6.12.76-linuxkit; Python/3.12.11)
+      - ms-fabric-cli/1.6.1 (None; Darwin/25.5.0; Python/3.12.13)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
@@ -26,15 +26,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '3227'
+      - '3271'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:09:08 GMT
+      - Mon, 22 Jun 2026 10:24:15 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 9b4bbf47-d81b-420e-8f29-be7f7022d3db
+      - 0ac62403-a6a3-4d41-9ba3-003c8602aba5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -60,7 +60,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (None; Linux/6.12.76-linuxkit; Python/3.12.11)
+      - ms-fabric-cli/1.6.1 (None; Darwin/25.5.0; Python/3.12.13)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
@@ -75,15 +75,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '3227'
+      - '3271'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:09:09 GMT
+      - Mon, 22 Jun 2026 10:24:16 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 7fa2ea2b-8df6-4d7d-806f-ffa179a9b2f7
+      - 99ad22cd-a211-49c1-a265-65387ef2f3a8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -109,7 +109,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (None; Linux/6.12.76-linuxkit; Python/3.12.11)
+      - ms-fabric-cli/1.6.1 (None; Darwin/25.5.0; Python/3.12.13)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/capacities
   response:
@@ -125,15 +125,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '462'
+      - '467'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:09:14 GMT
+      - Mon, 22 Jun 2026 10:24:20 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 4aaf4ac5-968d-424b-b2fc-8d0b6cf85d77
+      - 4125973b-3677-4f49-b023-d3d1c7e54013
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -162,13 +162,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (None; Linux/6.12.76-linuxkit; Python/3.12.11)
+      - ms-fabric-cli/1.6.1 (None; Darwin/25.5.0; Python/3.12.13)
     method: POST
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
     body:
-      string: '{"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a", "displayName": "fabriccli_WorkspacePerTestclass_000001",
-        "description": "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}'
+      string: '{"id": "01b1815a-ce26-4272-b8b1-5bb469afc785", "displayName": "fabriccli_WorkspacePerTestclass_000001",
+        "description": "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004",
+        "capacityRegion": "Central US"}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId,Location
@@ -177,17 +178,17 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '176'
+      - '196'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:09:20 GMT
+      - Mon, 22 Jun 2026 10:24:27 GMT
       Location:
-      - https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a
+      - https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785
       Pragma:
       - no-cache
       RequestId:
-      - 143453b7-f98d-4fe3-886b-fcdfbe94253d
+      - 7e828071-8289-4077-8d4d-e3457f16519e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -213,15 +214,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Linux/6.12.76-linuxkit; Python/3.12.11)
+      - ms-fabric-cli/1.6.1 (set; Darwin/25.5.0; Python/3.12.13)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
     body:
       string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
-        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "My workspace", "description": "", "type": "Personal"}, {"id": "01b1815a-ce26-4272-b8b1-5bb469afc785",
         "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
-        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004",
+        "capacityRegion": "Central US"}]}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId
@@ -230,15 +232,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '3266'
+      - '3305'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:10:55 GMT
+      - Mon, 22 Jun 2026 10:27:17 GMT
       Pragma:
       - no-cache
       RequestId:
-      - e36eba8a-b837-4f56-b1c2-1afe7bf5bdfc
+      - 9e78df05-b2a2-4ce4-843a-bda0398b43cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -264,9 +266,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Linux/6.12.76-linuxkit; Python/3.12.11)
+      - ms-fabric-cli/1.6.1 (set; Darwin/25.5.0; Python/3.12.13)
     method: GET
-    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
       string: '{"value": []}'
@@ -282,11 +284,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:10:56 GMT
+      - Mon, 22 Jun 2026 10:27:17 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 8e6ad6b9-06c4-4219-8a9e-c95d2ad90cca
+      - 6c9a0dc2-a403-4a19-b791-a85c6e9f0901
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -314,9 +316,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Linux/6.12.76-linuxkit; Python/3.12.11)
+      - ms-fabric-cli/1.6.1 (set; Darwin/25.5.0; Python/3.12.13)
     method: DELETE
-    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785
   response:
     body:
       string: ''
@@ -332,11 +334,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Tue, 16 Jun 2026 11:10:57 GMT
+      - Mon, 22 Jun 2026 10:27:18 GMT
       Pragma:
       - no-cache
       RequestId:
-      - dfb8c411-66a0-4958-a7fe-8ff070df1400
+      - 216a3d44-a475-48ff-88a9-7edcfacbac44
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:

--- a/tests/test_commands/recordings/test_commands/test_set/class_setup.yaml
+++ b/tests/test_commands/recordings/test_commands/test_set/class_setup.yaml
@@ -11,7 +11,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Darwin/25.4.0; Python/3.12.13)
+      - ms-fabric-cli/1.6.1 (None; Linux/6.12.76-linuxkit; Python/3.12.11)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
@@ -26,15 +26,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2561'
+      - '3227'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 13 May 2026 11:03:06 GMT
+      - Tue, 16 Jun 2026 11:09:08 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 93630144-c10b-421b-9f61-b4c9e96e53ce
+      - 9b4bbf47-d81b-420e-8f29-be7f7022d3db
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -60,7 +60,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Darwin/25.4.0; Python/3.12.13)
+      - ms-fabric-cli/1.6.1 (None; Linux/6.12.76-linuxkit; Python/3.12.11)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
@@ -75,15 +75,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2561'
+      - '3227'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 13 May 2026 11:03:08 GMT
+      - Tue, 16 Jun 2026 11:09:09 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 222a5ebf-a440-4c9b-8a2c-0e1e46b6b6ba
+      - 7fa2ea2b-8df6-4d7d-806f-ffa179a9b2f7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -109,7 +109,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Darwin/25.4.0; Python/3.12.13)
+      - ms-fabric-cli/1.6.1 (None; Linux/6.12.76-linuxkit; Python/3.12.11)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/capacities
   response:
@@ -125,15 +125,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '426'
+      - '462'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 13 May 2026 11:03:13 GMT
+      - Tue, 16 Jun 2026 11:09:14 GMT
       Pragma:
       - no-cache
       RequestId:
-      - dfb69fa0-b455-4808-ae5f-1a7ddef6e34b
+      - 4aaf4ac5-968d-424b-b2fc-8d0b6cf85d77
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -162,12 +162,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Darwin/25.4.0; Python/3.12.13)
+      - ms-fabric-cli/1.6.1 (None; Linux/6.12.76-linuxkit; Python/3.12.11)
     method: POST
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
     body:
-      string: '{"id": "81517fa4-30e3-42e6-b751-b36af1c8e99a", "displayName": "fabriccli_WorkspacePerTestclass_000001",
+      string: '{"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a", "displayName": "fabriccli_WorkspacePerTestclass_000001",
         "description": "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}'
     headers:
       Access-Control-Expose-Headers:
@@ -177,17 +177,17 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '175'
+      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 13 May 2026 11:03:21 GMT
+      - Tue, 16 Jun 2026 11:09:20 GMT
       Location:
-      - https://api.fabric.microsoft.com/v1/workspaces/81517fa4-30e3-42e6-b751-b36af1c8e99a
+      - https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a
       Pragma:
       - no-cache
       RequestId:
-      - 6f6fd3f9-2eeb-4e85-afe0-f530855a0a0f
+      - 143453b7-f98d-4fe3-886b-fcdfbe94253d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -213,13 +213,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Darwin/25.4.0; Python/3.12.13)
+      - ms-fabric-cli/1.6.1 (set; Linux/6.12.76-linuxkit; Python/3.12.11)
     method: GET
     uri: https://api.fabric.microsoft.com/v1/workspaces
   response:
     body:
       string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
-        "My workspace", "description": "", "type": "Personal"}, {"id": "81517fa4-30e3-42e6-b751-b36af1c8e99a",
+        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
         "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
         "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
     headers:
@@ -230,15 +230,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2595'
+      - '3266'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 13 May 2026 11:03:33 GMT
+      - Tue, 16 Jun 2026 11:10:55 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 5a815f03-74e2-4496-aae0-2364a02687cd
+      - e36eba8a-b837-4f56-b1c2-1afe7bf5bdfc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -264,9 +264,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Darwin/25.4.0; Python/3.12.13)
+      - ms-fabric-cli/1.6.1 (set; Linux/6.12.76-linuxkit; Python/3.12.11)
     method: GET
-    uri: https://api.fabric.microsoft.com/v1/workspaces/81517fa4-30e3-42e6-b751-b36af1c8e99a/items
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
   response:
     body:
       string: '{"value": []}'
@@ -282,11 +282,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 13 May 2026 11:03:34 GMT
+      - Tue, 16 Jun 2026 11:10:56 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 1283e8eb-846f-49ab-b1e4-4438ef0df0f9
+      - 8e6ad6b9-06c4-4219-8a9e-c95d2ad90cca
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -314,9 +314,9 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - ms-fabric-cli/1.6.1 (set; Darwin/25.4.0; Python/3.12.13)
+      - ms-fabric-cli/1.6.1 (set; Linux/6.12.76-linuxkit; Python/3.12.11)
     method: DELETE
-    uri: https://api.fabric.microsoft.com/v1/workspaces/81517fa4-30e3-42e6-b751-b36af1c8e99a
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a
   response:
     body:
       string: ''
@@ -332,11 +332,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Wed, 13 May 2026 11:03:35 GMT
+      - Tue, 16 Jun 2026 11:10:57 GMT
       Pragma:
       - no-cache
       RequestId:
-      - b0ec7a9f-0f36-4321-9c58-823c5894cd4c
+      - dfb8c411-66a0-4958-a7fe-8ff070df1400
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:

--- a/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_float_value_failure.yaml
+++ b/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_float_value_failure.yaml
@@ -33,11 +33,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:19 GMT
+      - Mon, 22 Jun 2026 10:26:17 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 3b313220-01d9-4f10-b8e0-5c53b9cd2e70
+      - df8f90be-0111-4a99-a682-9c752903cfb8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -81,11 +81,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:19 GMT
+      - Mon, 22 Jun 2026 10:26:17 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 8967598a-0877-4870-a9a0-0b99eb7903b8
+      - 5964ced7-4198-470d-ba1f-9f75d1431489
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -129,11 +129,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:20 GMT
+      - Mon, 22 Jun 2026 10:26:18 GMT
       Pragma:
       - no-cache
       RequestId:
-      - e1c5b100-76aa-4b99-97b1-06ef61a3268e
+      - 9c877753-61b0-4891-a734-73b6211c32cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -179,15 +179,15 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:22 GMT
+      - Mon, 22 Jun 2026 10:26:21 GMT
       ETag:
       - '""'
       Location:
-      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/878b4c3a-e131-41a0-abe3-1c4ef58bc5c0
       Pragma:
       - no-cache
       RequestId:
-      - 3584ddde-ac07-4f9c-9bb8-4b668605e36e
+      - 547bdf9b-690c-47a2-8c99-f5313933bfd8
       Retry-After:
       - '20'
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       request-redirected:
       - 'true'
       x-ms-operation-id:
-      - 6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - 878b4c3a-e131-41a0-abe3-1c4ef58bc5c0
     status:
       code: 202
       message: Accepted
@@ -219,11 +219,11 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/878b4c3a-e131-41a0-abe3-1c4ef58bc5c0
   response:
     body:
-      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-22T10:25:22.0560649",
-        "lastUpdatedTimeUtc": "2026-06-22T10:25:38.4270342", "percentComplete": 100,
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-22T10:26:19.9258538",
+        "lastUpdatedTimeUtc": "2026-06-22T10:26:33.856033", "percentComplete": 100,
         "error": null}'
     headers:
       Access-Control-Expose-Headers:
@@ -233,17 +233,17 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '131'
+      - '130'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:43 GMT
+      - Mon, 22 Jun 2026 10:26:41 GMT
       Location:
-      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace/result
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/878b4c3a-e131-41a0-abe3-1c4ef58bc5c0/result
       Pragma:
       - no-cache
       RequestId:
-      - 4d44bc91-4cf7-4b42-9a98-0f340773db0d
+      - 48485768-827a-4d17-9bbe-69b482a325e4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -251,7 +251,7 @@ interactions:
       X-Frame-Options:
       - deny
       x-ms-operation-id:
-      - 6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - 878b4c3a-e131-41a0-abe3-1c4ef58bc5c0
     status:
       code: 200
       message: OK
@@ -269,10 +269,10 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace/result
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/878b4c3a-e131-41a0-abe3-1c4ef58bc5c0/result
   response:
     body:
-      string: '{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
+      string: '{"id": "06fb3b23-a9f0-4196-893e-a4bf6a3f4200", "type": "SQLDatabase",
         "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}'
     headers:
       Access-Control-Expose-Headers:
@@ -284,11 +284,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 22 Jun 2026 10:25:44 GMT
+      - Mon, 22 Jun 2026 10:26:42 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 6f059883-1c58-4bc6-ac6e-2a68a59e171d
+      - 58db35c2-3750-4f05-867f-c5fa47b776f1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Transfer-Encoding:
@@ -334,11 +334,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:45 GMT
+      - Mon, 22 Jun 2026 10:26:43 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 18dc2d84-5112-4c21-9fd5-eb6bb65bf39e
+      - 83f601e5-881e-48a9-ac10-0c69ada7067a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -369,7 +369,7 @@ interactions:
     uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
-      string: '{"value": [{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
+      string: '{"value": [{"id": "06fb3b23-a9f0-4196-893e-a4bf6a3f4200", "type": "SQLDatabase",
         "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -383,11 +383,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:45 GMT
+      - Mon, 22 Jun 2026 10:26:43 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 809f5e6a-6a37-403d-a7f1-4c650c037e19
+      - ee73a4ee-1cae-4dfb-a0e1-30e9ab4e74c3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -435,11 +435,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:46 GMT
+      - Mon, 22 Jun 2026 10:26:44 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 3f5940e9-05c7-4e25-9628-fb1cdc345c2a
+      - 2430b5c3-fd42-4ed0-8a07-4ecee85e9d2f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -470,7 +470,7 @@ interactions:
     uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
-      string: '{"value": [{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
+      string: '{"value": [{"id": "06fb3b23-a9f0-4196-893e-a4bf6a3f4200", "type": "SQLDatabase",
         "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -484,11 +484,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:47 GMT
+      - Mon, 22 Jun 2026 10:26:45 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 79c74621-d94b-483f-bf3b-4a31d92c6de1
+      - 06ac341a-7f93-4981-9773-666212e78084
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -518,7 +518,7 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: DELETE
-    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items/9e74fbf2-a811-43a1-aa74-b82471a97970
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items/06fb3b23-a9f0-4196-893e-a4bf6a3f4200
   response:
     body:
       string: ''
@@ -534,11 +534,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Mon, 22 Jun 2026 10:25:46 GMT
+      - Mon, 22 Jun 2026 10:26:46 GMT
       Pragma:
       - no-cache
       RequestId:
-      - b4d39f05-9d9f-4594-ab21-71a9810ca8cb
+      - 0245e37b-ef22-4509-bb1d-69c26f3758dc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:

--- a/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_invalid_value_failure.yaml
+++ b/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_invalid_value_failure.yaml
@@ -1,0 +1,552 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '3266'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:09:54 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 7236c1a1-4344-44bb-bedd-988da2e07993
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:09:55 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 2eb10b6e-816b-4e5c-b231-6f0c7cc9023d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:09:56 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 54101232-20cf-48c1-ad11-40c35a965765
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"displayName": "fabcli000001", "type": "SQLDatabase", "folderId": null}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/sqlDatabases
+  response:
+    body:
+      string: 'null'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,ETag,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:09:58 GMT
+      ETag:
+      - '""'
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/59d8720f-626c-4227-a1dc-773dbdc94806
+      Pragma:
+      - no-cache
+      RequestId:
+      - e7bc4872-8c7b-4400-bffd-82b38a338a73
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+      x-ms-operation-id:
+      - 59d8720f-626c-4227-a1dc-773dbdc94806
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/59d8720f-626c-4227-a1dc-773dbdc94806
+  response:
+    body:
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-16T11:09:57.679029",
+        "lastUpdatedTimeUtc": "2026-06-16T11:10:12.9882692", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:19 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/59d8720f-626c-4227-a1dc-773dbdc94806/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - f26e01d0-a97c-4b22-99e8-1bc9b15308d0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - 59d8720f-626c-4227-a1dc-773dbdc94806
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/59d8720f-626c-4227-a1dc-773dbdc94806/result
+  response:
+    body:
+      string: '{"id": "1d863900-eccc-447a-9cfb-5296cb734648", "type": "SQLDatabase",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Jun 2026 11:10:19 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 80b19a02-04d1-4926-bb4f-2fa2fd97a0c6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '3266'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:20 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 9ec3a2c7-d17c-4d57-94e4-57c7038252d9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+  response:
+    body:
+      string: '{"value": [{"id": "1d863900-eccc-447a-9cfb-5296cb734648", "type": "SQLDatabase",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:21 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - b45976b4-3bfe-4a34-b9e4-c93715f6699c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '3266'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:22 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 3e6605d9-fea6-47c3-84e9-b247f693d5f9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+  response:
+    body:
+      string: '{"value": [{"id": "1d863900-eccc-447a-9cfb-5296cb734648", "type": "SQLDatabase",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:23 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 26a88061-73fd-4841-8889-461b60cd2688
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: DELETE
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items/1d863900-eccc-447a-9cfb-5296cb734648
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Tue, 16 Jun 2026 11:10:23 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 5aae77ac-51af-4482-b321-1f39054bdef7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_invalid_value_failure.yaml
+++ b/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_invalid_value_failure.yaml
@@ -17,9 +17,10 @@ interactions:
   response:
     body:
       string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
-        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "My workspace", "description": "", "type": "Personal"}, {"id": "01b1815a-ce26-4272-b8b1-5bb469afc785",
         "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
-        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004",
+        "capacityRegion": "Central US"}]}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId
@@ -28,15 +29,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '3266'
+      - '3305'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:09:54 GMT
+      - Mon, 22 Jun 2026 10:24:27 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 7236c1a1-4344-44bb-bedd-988da2e07993
+      - 281b7d03-abfc-406b-91d4-569129bdacc8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -64,7 +65,7 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
       string: '{"value": []}'
@@ -80,11 +81,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:09:55 GMT
+      - Mon, 22 Jun 2026 10:24:29 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 2eb10b6e-816b-4e5c-b231-6f0c7cc9023d
+      - 474bd47a-f775-459a-b40c-1a76a6d239a4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -112,7 +113,7 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
       string: '{"value": []}'
@@ -128,11 +129,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:09:56 GMT
+      - Mon, 22 Jun 2026 10:24:29 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 54101232-20cf-48c1-ad11-40c35a965765
+      - 24481788-4ac5-4d76-a8ef-39d332f8c686
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -162,7 +163,7 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: POST
-    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/sqlDatabases
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/sqlDatabases
   response:
     body:
       string: 'null'
@@ -178,15 +179,15 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:09:58 GMT
+      - Mon, 22 Jun 2026 10:24:31 GMT
       ETag:
       - '""'
       Location:
-      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/59d8720f-626c-4227-a1dc-773dbdc94806
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/821c64d6-0c50-42b7-91ed-417c1d506a04
       Pragma:
       - no-cache
       RequestId:
-      - e7bc4872-8c7b-4400-bffd-82b38a338a73
+      - cfe1f20c-f14a-4ad6-b168-003efcd052d5
       Retry-After:
       - '20'
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       request-redirected:
       - 'true'
       x-ms-operation-id:
-      - 59d8720f-626c-4227-a1dc-773dbdc94806
+      - 821c64d6-0c50-42b7-91ed-417c1d506a04
     status:
       code: 202
       message: Accepted
@@ -218,31 +219,33 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/59d8720f-626c-4227-a1dc-773dbdc94806
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/821c64d6-0c50-42b7-91ed-417c1d506a04
   response:
     body:
-      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-16T11:09:57.679029",
-        "lastUpdatedTimeUtc": "2026-06-16T11:10:12.9882692", "percentComplete": 100,
+      string: '{"status": "Running", "createdTimeUtc": "2026-06-22T10:24:30.98695",
+        "lastUpdatedTimeUtc": "2026-06-22T10:24:30.98695", "percentComplete": null,
         "error": null}'
     headers:
       Access-Control-Expose-Headers:
-      - RequestId,Location,x-ms-operation-id
+      - RequestId,Location,Retry-After,x-ms-operation-id
       Cache-Control:
       - no-store, must-revalidate, no-cache
       Content-Encoding:
       - gzip
       Content-Length:
-      - '132'
+      - '122'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:10:19 GMT
+      - Mon, 22 Jun 2026 10:24:52 GMT
       Location:
-      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/59d8720f-626c-4227-a1dc-773dbdc94806/result
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/821c64d6-0c50-42b7-91ed-417c1d506a04
       Pragma:
       - no-cache
       RequestId:
-      - f26e01d0-a97c-4b22-99e8-1bc9b15308d0
+      - 14e2211c-0782-4c52-8c0e-1adb7c3be229
+      Retry-After:
+      - '20'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -250,7 +253,7 @@ interactions:
       X-Frame-Options:
       - deny
       x-ms-operation-id:
-      - 59d8720f-626c-4227-a1dc-773dbdc94806
+      - 821c64d6-0c50-42b7-91ed-417c1d506a04
     status:
       code: 200
       message: OK
@@ -268,11 +271,61 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/59d8720f-626c-4227-a1dc-773dbdc94806/result
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/821c64d6-0c50-42b7-91ed-417c1d506a04
   response:
     body:
-      string: '{"id": "1d863900-eccc-447a-9cfb-5296cb734648", "type": "SQLDatabase",
-        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}'
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-22T10:24:30.98695",
+        "lastUpdatedTimeUtc": "2026-06-22T10:24:54.6096087", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '130'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 22 Jun 2026 10:25:13 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/821c64d6-0c50-42b7-91ed-417c1d506a04/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - c961ec81-59c2-4c8d-83ab-f2af261fda9e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - 821c64d6-0c50-42b7-91ed-417c1d506a04
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/821c64d6-0c50-42b7-91ed-417c1d506a04/result
+  response:
+    body:
+      string: '{"id": "ca9f7e25-2bd9-458e-aeb1-484742dd2758", "type": "SQLDatabase",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId
@@ -283,11 +336,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Jun 2026 11:10:19 GMT
+      - Mon, 22 Jun 2026 10:25:13 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 80b19a02-04d1-4926-bb4f-2fa2fd97a0c6
+      - 96b8b80d-4fcc-4f70-af76-c3e1119fce75
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Transfer-Encoding:
@@ -317,9 +370,10 @@ interactions:
   response:
     body:
       string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
-        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "My workspace", "description": "", "type": "Personal"}, {"id": "01b1815a-ce26-4272-b8b1-5bb469afc785",
         "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
-        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004",
+        "capacityRegion": "Central US"}]}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId
@@ -328,15 +382,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '3266'
+      - '3305'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:10:20 GMT
+      - Mon, 22 Jun 2026 10:25:14 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 9ec3a2c7-d17c-4d57-94e4-57c7038252d9
+      - a05d90ed-9ded-4ccf-a744-753c32d15309
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -364,11 +418,13 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
-      string: '{"value": [{"id": "1d863900-eccc-447a-9cfb-5296cb734648", "type": "SQLDatabase",
-        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}]}'
+      string: '{"value": [{"id": "e0cbda9c-a9a2-4f06-bef0-1570eff0aae1", "type": "SQLEndpoint",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"},
+        {"id": "ca9f7e25-2bd9-458e-aeb1-484742dd2758", "type": "SQLDatabase", "displayName":
+        "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId
@@ -377,15 +433,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '170'
+      - '211'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:10:21 GMT
+      - Mon, 22 Jun 2026 10:25:15 GMT
       Pragma:
       - no-cache
       RequestId:
-      - b45976b4-3bfe-4a34-b9e4-c93715f6699c
+      - 5bdf565b-732e-438a-8044-db413a0f6327
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -417,9 +473,10 @@ interactions:
   response:
     body:
       string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
-        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "My workspace", "description": "", "type": "Personal"}, {"id": "01b1815a-ce26-4272-b8b1-5bb469afc785",
         "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
-        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004",
+        "capacityRegion": "Central US"}]}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId
@@ -428,15 +485,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '3266'
+      - '3305'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:10:22 GMT
+      - Mon, 22 Jun 2026 10:25:16 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 3e6605d9-fea6-47c3-84e9-b247f693d5f9
+      - 9d68ae41-e34c-4ecc-b9d4-37ab9af836e5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -464,11 +521,13 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
-      string: '{"value": [{"id": "1d863900-eccc-447a-9cfb-5296cb734648", "type": "SQLDatabase",
-        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}]}'
+      string: '{"value": [{"id": "e0cbda9c-a9a2-4f06-bef0-1570eff0aae1", "type": "SQLEndpoint",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"},
+        {"id": "ca9f7e25-2bd9-458e-aeb1-484742dd2758", "type": "SQLDatabase", "displayName":
+        "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId
@@ -477,15 +536,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '170'
+      - '211'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jun 2026 11:10:23 GMT
+      - Mon, 22 Jun 2026 10:25:17 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 26a88061-73fd-4841-8889-461b60cd2688
+      - bcc2f314-8122-42a1-a74b-4a2547d5f95f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -515,7 +574,7 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: DELETE
-    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items/1d863900-eccc-447a-9cfb-5296cb734648
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items/ca9f7e25-2bd9-458e-aeb1-484742dd2758
   response:
     body:
       string: ''
@@ -531,11 +590,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Tue, 16 Jun 2026 11:10:23 GMT
+      - Mon, 22 Jun 2026 10:25:18 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 5aae77ac-51af-4482-b321-1f39054bdef7
+      - c32a042a-f398-42f1-9938-503982bbb0f9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:

--- a/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_negative_value_failure.yaml
+++ b/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_negative_value_failure.yaml
@@ -33,11 +33,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:19 GMT
+      - Mon, 22 Jun 2026 10:25:47 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 3b313220-01d9-4f10-b8e0-5c53b9cd2e70
+      - 173d424f-0dd3-4f10-b38c-ddd6692105bc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -81,11 +81,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:19 GMT
+      - Mon, 22 Jun 2026 10:25:48 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 8967598a-0877-4870-a9a0-0b99eb7903b8
+      - c6ea8a01-a470-4881-83e8-f197772eb22a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -129,11 +129,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:20 GMT
+      - Mon, 22 Jun 2026 10:25:49 GMT
       Pragma:
       - no-cache
       RequestId:
-      - e1c5b100-76aa-4b99-97b1-06ef61a3268e
+      - 75cd1ab6-07bd-425d-aa55-2702e0ceebcf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -179,15 +179,15 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:22 GMT
+      - Mon, 22 Jun 2026 10:25:51 GMT
       ETag:
       - '""'
       Location:
-      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/d3532b9e-9e37-4ff7-897c-4d77be44802b
       Pragma:
       - no-cache
       RequestId:
-      - 3584ddde-ac07-4f9c-9bb8-4b668605e36e
+      - 54dcf807-3772-4eb2-ab41-55cffc1f675d
       Retry-After:
       - '20'
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       request-redirected:
       - 'true'
       x-ms-operation-id:
-      - 6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - d3532b9e-9e37-4ff7-897c-4d77be44802b
     status:
       code: 202
       message: Accepted
@@ -219,11 +219,11 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/d3532b9e-9e37-4ff7-897c-4d77be44802b
   response:
     body:
-      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-22T10:25:22.0560649",
-        "lastUpdatedTimeUtc": "2026-06-22T10:25:38.4270342", "percentComplete": 100,
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-22T10:25:50.7608466",
+        "lastUpdatedTimeUtc": "2026-06-22T10:26:10.1126261", "percentComplete": 100,
         "error": null}'
     headers:
       Access-Control-Expose-Headers:
@@ -237,13 +237,13 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:43 GMT
+      - Mon, 22 Jun 2026 10:26:12 GMT
       Location:
-      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace/result
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/d3532b9e-9e37-4ff7-897c-4d77be44802b/result
       Pragma:
       - no-cache
       RequestId:
-      - 4d44bc91-4cf7-4b42-9a98-0f340773db0d
+      - 50785f47-fbac-4c87-aa58-dbbb27ee3b1d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -251,7 +251,7 @@ interactions:
       X-Frame-Options:
       - deny
       x-ms-operation-id:
-      - 6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - d3532b9e-9e37-4ff7-897c-4d77be44802b
     status:
       code: 200
       message: OK
@@ -269,10 +269,10 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace/result
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/d3532b9e-9e37-4ff7-897c-4d77be44802b/result
   response:
     body:
-      string: '{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
+      string: '{"id": "6ea15be2-38d5-4f3c-bff4-5f4f40d9a877", "type": "SQLDatabase",
         "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}'
     headers:
       Access-Control-Expose-Headers:
@@ -284,11 +284,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 22 Jun 2026 10:25:44 GMT
+      - Mon, 22 Jun 2026 10:26:12 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 6f059883-1c58-4bc6-ac6e-2a68a59e171d
+      - 9fe4b946-338c-43bb-b0be-9a42e12b0a02
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Transfer-Encoding:
@@ -334,11 +334,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:45 GMT
+      - Mon, 22 Jun 2026 10:26:13 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 18dc2d84-5112-4c21-9fd5-eb6bb65bf39e
+      - b0ddd7fb-93c7-483c-8d03-69adf0dc0ffb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -369,7 +369,7 @@ interactions:
     uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
-      string: '{"value": [{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
+      string: '{"value": [{"id": "6ea15be2-38d5-4f3c-bff4-5f4f40d9a877", "type": "SQLDatabase",
         "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -379,15 +379,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '171'
+      - '170'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:45 GMT
+      - Mon, 22 Jun 2026 10:26:14 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 809f5e6a-6a37-403d-a7f1-4c650c037e19
+      - 2f5ee7d2-e65c-4d4b-a9e6-facdcf03e303
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -435,11 +435,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:46 GMT
+      - Mon, 22 Jun 2026 10:26:14 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 3f5940e9-05c7-4e25-9628-fb1cdc345c2a
+      - 816619d3-179b-4f15-b842-355d29a6f658
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -470,8 +470,10 @@ interactions:
     uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
-      string: '{"value": [{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
-        "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
+      string: '{"value": [{"id": "566cd624-6aea-4f8d-919d-dc762370ec2d", "type": "SQLEndpoint",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"},
+        {"id": "6ea15be2-38d5-4f3c-bff4-5f4f40d9a877", "type": "SQLDatabase", "displayName":
+        "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
     headers:
       Access-Control-Expose-Headers:
       - RequestId
@@ -480,15 +482,15 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '171'
+      - '213'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:47 GMT
+      - Mon, 22 Jun 2026 10:26:15 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 79c74621-d94b-483f-bf3b-4a31d92c6de1
+      - 543eb9c0-f7a7-4daa-a8b9-dcf09c959e5b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -518,7 +520,7 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: DELETE
-    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items/9e74fbf2-a811-43a1-aa74-b82471a97970
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items/6ea15be2-38d5-4f3c-bff4-5f4f40d9a877
   response:
     body:
       string: ''
@@ -534,11 +536,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Mon, 22 Jun 2026 10:25:46 GMT
+      - Mon, 22 Jun 2026 10:26:16 GMT
       Pragma:
       - no-cache
       RequestId:
-      - b4d39f05-9d9f-4594-ab21-71a9810ca8cb
+      - e949b6a7-acc5-4077-86ec-b10fc520212d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:

--- a/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_out_of_range_failure.yaml
+++ b/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_out_of_range_failure.yaml
@@ -1,0 +1,552 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '3266'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:24 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - ff847db7-9f96-4d56-9c28-3cd937b075e2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:25 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 7771f366-3d69-4c57-992e-89db30c66108
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:27 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 48867f01-4d58-47f8-9a35-f5dcd5b8f64f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"displayName": "fabcli000001", "type": "SQLDatabase", "folderId": null}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/sqlDatabases
+  response:
+    body:
+      string: 'null'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,ETag,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:28 GMT
+      ETag:
+      - '""'
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/a685f62a-9aaa-489f-948c-35967b014666
+      Pragma:
+      - no-cache
+      RequestId:
+      - 63f15480-bb2a-4ede-8626-a1cde3bc609b
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+      x-ms-operation-id:
+      - a685f62a-9aaa-489f-948c-35967b014666
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/a685f62a-9aaa-489f-948c-35967b014666
+  response:
+    body:
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-16T11:10:28.4106976",
+        "lastUpdatedTimeUtc": "2026-06-16T11:10:40.2005894", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '131'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:49 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/a685f62a-9aaa-489f-948c-35967b014666/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - e3de0678-f999-4538-ac0e-6228f8dd238f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - a685f62a-9aaa-489f-948c-35967b014666
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/a685f62a-9aaa-489f-948c-35967b014666/result
+  response:
+    body:
+      string: '{"id": "3d931b64-e790-425a-a1f7-bffd2f2948e6", "type": "SQLDatabase",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Jun 2026 11:10:50 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - eaf82fc0-8ba4-483b-8bf2-a15b6ed47182
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '3266'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:51 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 4b9e83a3-23b9-4a04-b738-8845390828e5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+  response:
+    body:
+      string: '{"value": [{"id": "3d931b64-e790-425a-a1f7-bffd2f2948e6", "type": "SQLDatabase",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:52 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - f84c2d51-f8e5-4249-882b-e5eeadc62cf9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '3266'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:53 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 23515bb3-60a6-455c-a11d-95ee20c7ddd4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items
+  response:
+    body:
+      string: '{"value": [{"id": "3d931b64-e790-425a-a1f7-bffd2f2948e6", "type": "SQLDatabase",
+        "displayName": "fabcli000001", "description": "", "workspaceId": "fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Jun 2026 11:10:53 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 9247750c-e518-40f3-858a-2be170098b07
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.6.1
+    method: DELETE
+    uri: https://api.fabric.microsoft.com/v1/workspaces/fd1b2648-dbb2-442c-b4c7-73b02f7f8a2a/items/3d931b64-e790-425a-a1f7-bffd2f2948e6
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Tue, 16 Jun 2026 11:10:54 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 1e99a1ca-f7e1-46e2-bf60-6ffc5d3681a9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_zero_value_failure.yaml
+++ b/tests/test_commands/recordings/test_commands/test_set/test_set_sql_database_backup_retention_days_zero_value_failure.yaml
@@ -33,11 +33,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:19 GMT
+      - Mon, 22 Jun 2026 10:26:46 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 3b313220-01d9-4f10-b8e0-5c53b9cd2e70
+      - 2a0a181c-d415-4537-abf2-6eecbd91caf9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -81,11 +81,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:19 GMT
+      - Mon, 22 Jun 2026 10:26:47 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 8967598a-0877-4870-a9a0-0b99eb7903b8
+      - 868fcb51-8a7f-4940-8fa7-2a859b88c9bb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -129,11 +129,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:20 GMT
+      - Mon, 22 Jun 2026 10:26:47 GMT
       Pragma:
       - no-cache
       RequestId:
-      - e1c5b100-76aa-4b99-97b1-06ef61a3268e
+      - a7518c3b-dcda-45d5-bc89-bd1f1bc868fe
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -179,15 +179,15 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:22 GMT
+      - Mon, 22 Jun 2026 10:26:49 GMT
       ETag:
       - '""'
       Location:
-      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/76572303-0488-47fe-9c00-654473163fea
       Pragma:
       - no-cache
       RequestId:
-      - 3584ddde-ac07-4f9c-9bb8-4b668605e36e
+      - e42ff147-1d6d-47cd-bd30-7c0756a720fb
       Retry-After:
       - '20'
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       request-redirected:
       - 'true'
       x-ms-operation-id:
-      - 6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - 76572303-0488-47fe-9c00-654473163fea
     status:
       code: 202
       message: Accepted
@@ -219,11 +219,11 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/76572303-0488-47fe-9c00-654473163fea
   response:
     body:
-      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-22T10:25:22.0560649",
-        "lastUpdatedTimeUtc": "2026-06-22T10:25:38.4270342", "percentComplete": 100,
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-06-22T10:26:49.3589311",
+        "lastUpdatedTimeUtc": "2026-06-22T10:27:09.6260271", "percentComplete": 100,
         "error": null}'
     headers:
       Access-Control-Expose-Headers:
@@ -233,17 +233,17 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '131'
+      - '133'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:43 GMT
+      - Mon, 22 Jun 2026 10:27:10 GMT
       Location:
-      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace/result
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/76572303-0488-47fe-9c00-654473163fea/result
       Pragma:
       - no-cache
       RequestId:
-      - 4d44bc91-4cf7-4b42-9a98-0f340773db0d
+      - aa412e91-9224-468e-966d-92878771dfc4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -251,7 +251,7 @@ interactions:
       X-Frame-Options:
       - deny
       x-ms-operation-id:
-      - 6426aca4-61c1-4a0e-bf98-d79a3d19bace
+      - 76572303-0488-47fe-9c00-654473163fea
     status:
       code: 200
       message: OK
@@ -269,10 +269,10 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: GET
-    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6426aca4-61c1-4a0e-bf98-d79a3d19bace/result
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/76572303-0488-47fe-9c00-654473163fea/result
   response:
     body:
-      string: '{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
+      string: '{"id": "5882b1b4-43e7-4300-aad7-a9b884aca7a7", "type": "SQLDatabase",
         "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}'
     headers:
       Access-Control-Expose-Headers:
@@ -284,11 +284,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 22 Jun 2026 10:25:44 GMT
+      - Mon, 22 Jun 2026 10:27:11 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 6f059883-1c58-4bc6-ac6e-2a68a59e171d
+      - b27d7ea9-626f-4d04-b2d1-e6ae19f55c0d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Transfer-Encoding:
@@ -334,11 +334,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:45 GMT
+      - Mon, 22 Jun 2026 10:27:12 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 18dc2d84-5112-4c21-9fd5-eb6bb65bf39e
+      - bf800864-6313-4b1c-b457-1832d052eb5a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -369,7 +369,7 @@ interactions:
     uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
-      string: '{"value": [{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
+      string: '{"value": [{"id": "5882b1b4-43e7-4300-aad7-a9b884aca7a7", "type": "SQLDatabase",
         "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -383,11 +383,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:45 GMT
+      - Mon, 22 Jun 2026 10:27:13 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 809f5e6a-6a37-403d-a7f1-4c650c037e19
+      - 8a74eb80-2b91-4f2f-a3e9-99651fa0fd5c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -435,11 +435,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:46 GMT
+      - Mon, 22 Jun 2026 10:27:13 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 3f5940e9-05c7-4e25-9628-fb1cdc345c2a
+      - 15e699da-5f8d-4a1c-9244-876ac35d5ea6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -470,7 +470,7 @@ interactions:
     uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items
   response:
     body:
-      string: '{"value": [{"id": "9e74fbf2-a811-43a1-aa74-b82471a97970", "type": "SQLDatabase",
+      string: '{"value": [{"id": "5882b1b4-43e7-4300-aad7-a9b884aca7a7", "type": "SQLDatabase",
         "displayName": "fabcli000001", "description": "", "workspaceId": "01b1815a-ce26-4272-b8b1-5bb469afc785"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -484,11 +484,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 22 Jun 2026 10:25:47 GMT
+      - Mon, 22 Jun 2026 10:27:15 GMT
       Pragma:
       - no-cache
       RequestId:
-      - 79c74621-d94b-483f-bf3b-4a31d92c6de1
+      - 6eb65d70-c1f4-4524-b600-371cb22eb35a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -518,7 +518,7 @@ interactions:
       User-Agent:
       - ms-fabric-cli-test/1.6.1
     method: DELETE
-    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items/9e74fbf2-a811-43a1-aa74-b82471a97970
+    uri: https://api.fabric.microsoft.com/v1/workspaces/01b1815a-ce26-4272-b8b1-5bb469afc785/items/5882b1b4-43e7-4300-aad7-a9b884aca7a7
   response:
     body:
       string: ''
@@ -534,11 +534,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Mon, 22 Jun 2026 10:25:46 GMT
+      - Mon, 22 Jun 2026 10:27:16 GMT
       Pragma:
       - no-cache
       RequestId:
-      - b4d39f05-9d9f-4594-ab21-71a9810ca8cb
+      - 4b7271aa-78a2-46ad-a8ea-921b4167442d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:

--- a/tests/test_commands/test_set.py
+++ b/tests/test_commands/test_set.py
@@ -27,7 +27,6 @@ from tests.test_commands.conftest import (
     set_item_metadata_success_params,
     set_item_metadata_success_params_complete,
     set_item_metadata_for_all_types_success_item_params,
-    set_item_metadata_success_params,
     set_workspace_success_params,
     set_sparkpool_success_params,
     set_capacity_success_params,
@@ -239,6 +238,66 @@ class TestSET:
         get(variable_library.full_path, query="properties.activeValueSetName")
         assert "Default value set" in str(
             mock_questionary_print.call_args[0][0])
+
+    def test_set_sql_database_backup_retention_days_invalid_value_failure(
+        self,
+        item_factory,
+        cli_executor,
+        assert_fabric_cli_error,
+        mock_questionary_print,
+        mock_print_done,
+        mock_upsert_item_to_cache,
+    ):
+        """Test that setting backupRetentionDays with non-integer value fails."""
+        # Setup
+        sql_database = item_factory(ItemType.SQL_DATABASE)
+
+        # Reset mocks
+        mock_questionary_print.reset_mock()
+        mock_print_done.reset_mock()
+        mock_upsert_item_to_cache.reset_mock()
+
+        # Execute command with invalid (non-integer) value
+        cli_executor.exec_command(
+            f"set {sql_database.full_path} --query properties.backupRetentionDays --input seven --force"
+        )
+
+        # Assert
+        assert_fabric_cli_error(
+            constant.ERROR_INVALID_INPUT,
+            "backupRetentionDays",
+        )
+        mock_upsert_item_to_cache.assert_not_called()
+
+    def test_set_sql_database_backup_retention_days_out_of_range_failure(
+        self,
+        item_factory,
+        cli_executor,
+        assert_fabric_cli_error,
+        mock_questionary_print,
+        mock_print_done,
+        mock_upsert_item_to_cache,
+    ):
+        """Test that setting backupRetentionDays with out-of-range value fails."""
+        # Setup
+        sql_database = item_factory(ItemType.SQL_DATABASE)
+
+        # Reset mocks
+        mock_questionary_print.reset_mock()
+        mock_print_done.reset_mock()
+        mock_upsert_item_to_cache.reset_mock()
+
+        # Execute command with out-of-range value (above max of 35)
+        cli_executor.exec_command(
+            f"set {sql_database.full_path} --query properties.backupRetentionDays --input 100 --force"
+        )
+
+        # Assert
+        assert_fabric_cli_error(
+            constant.ERROR_INVALID_INPUT,
+            "backupRetentionDays",
+        )
+        mock_upsert_item_to_cache.assert_not_called()
 
     # endregion
 

--- a/tests/test_commands/test_set.py
+++ b/tests/test_commands/test_set.py
@@ -265,7 +265,7 @@ class TestSET:
         # Assert
         assert_fabric_cli_error(
             constant.ERROR_INVALID_INPUT,
-            "backupRetentionDays",
+            "backup retention days",
         )
         mock_upsert_item_to_cache.assert_not_called()
 
@@ -295,7 +295,97 @@ class TestSET:
         # Assert
         assert_fabric_cli_error(
             constant.ERROR_INVALID_INPUT,
-            "backupRetentionDays",
+            "backup retention days",
+        )
+        mock_upsert_item_to_cache.assert_not_called()
+
+    def test_set_sql_database_backup_retention_days_negative_value_failure(
+        self,
+        item_factory,
+        cli_executor,
+        assert_fabric_cli_error,
+        mock_questionary_print,
+        mock_print_done,
+        mock_upsert_item_to_cache,
+    ):
+        """Test that setting backupRetentionDays with negative value fails."""
+        # Setup
+        sql_database = item_factory(ItemType.SQL_DATABASE)
+
+        # Reset mocks
+        mock_questionary_print.reset_mock()
+        mock_print_done.reset_mock()
+        mock_upsert_item_to_cache.reset_mock()
+
+        # Execute command with negative value
+        cli_executor.exec_command(
+            f"set {sql_database.full_path} --query properties.backupRetentionDays --input -5 --force"
+        )
+
+        # Assert
+        assert_fabric_cli_error(
+            constant.ERROR_INVALID_INPUT,
+            "backup retention days",
+        )
+        mock_upsert_item_to_cache.assert_not_called()
+
+    def test_set_sql_database_backup_retention_days_float_value_failure(
+        self,
+        item_factory,
+        cli_executor,
+        assert_fabric_cli_error,
+        mock_questionary_print,
+        mock_print_done,
+        mock_upsert_item_to_cache,
+    ):
+        """Test that setting backupRetentionDays with float value fails."""
+        # Setup
+        sql_database = item_factory(ItemType.SQL_DATABASE)
+
+        # Reset mocks
+        mock_questionary_print.reset_mock()
+        mock_print_done.reset_mock()
+        mock_upsert_item_to_cache.reset_mock()
+
+        # Execute command with float value
+        cli_executor.exec_command(
+            f"set {sql_database.full_path} --query properties.backupRetentionDays --input 7.5 --force"
+        )
+
+        # Assert
+        assert_fabric_cli_error(
+            constant.ERROR_INVALID_INPUT,
+            "backup retention days",
+        )
+        mock_upsert_item_to_cache.assert_not_called()
+
+    def test_set_sql_database_backup_retention_days_zero_value_failure(
+        self,
+        item_factory,
+        cli_executor,
+        assert_fabric_cli_error,
+        mock_questionary_print,
+        mock_print_done,
+        mock_upsert_item_to_cache,
+    ):
+        """Test that setting backupRetentionDays with zero value fails."""
+        # Setup
+        sql_database = item_factory(ItemType.SQL_DATABASE)
+
+        # Reset mocks
+        mock_questionary_print.reset_mock()
+        mock_print_done.reset_mock()
+        mock_upsert_item_to_cache.reset_mock()
+
+        # Execute command with zero value (below min of 1)
+        cli_executor.exec_command(
+            f"set {sql_database.full_path} --query properties.backupRetentionDays --input 0 --force"
+        )
+
+        # Assert
+        assert_fabric_cli_error(
+            constant.ERROR_INVALID_INPUT,
+            "backup retention days",
         )
         mock_upsert_item_to_cache.assert_not_called()
 

--- a/tests/test_utils/test_fab_cmd_set_utils.py
+++ b/tests/test_utils/test_fab_cmd_set_utils.py
@@ -205,3 +205,76 @@ def test_update_cache_with_custom_name_key_success():
 
     assert mock_element._name == "New Spark Pool Name"
     mock_cache_update_func.assert_called_once_with(mock_element)
+
+
+# SQLDatabase validation tests
+
+
+def test_validate_sql_database_property_backup_retention_days_valid_int_success():
+    from fabric_cli.utils.fab_cmd_set_utils import validate_sql_database_property
+
+    # Valid integer within range should not raise
+    validate_sql_database_property("properties.backupRetentionDays", "7")
+    validate_sql_database_property("properties.backupRetentionDays", "14")
+    validate_sql_database_property("properties.backupRetentionDays", "21")
+    validate_sql_database_property("properties.backupRetentionDays", "35")
+    validate_sql_database_property("properties.backupRetentionDays", "1")
+
+
+def test_validate_sql_database_property_backup_retention_days_out_of_range_failure():
+    from fabric_cli.core import fab_constant
+    from fabric_cli.utils.fab_cmd_set_utils import validate_sql_database_property
+
+    # Value below minimum
+    with pytest.raises(FabricCLIError) as exc_info:
+        validate_sql_database_property("properties.backupRetentionDays", "0")
+    assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+    assert "backupRetentionDays" in str(exc_info.value)
+    assert "1" in str(exc_info.value)
+    assert "35" in str(exc_info.value)
+
+    # Value above maximum
+    with pytest.raises(FabricCLIError) as exc_info:
+        validate_sql_database_property("properties.backupRetentionDays", "36")
+    assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+
+
+def test_validate_sql_database_property_backup_retention_days_not_integer_failure():
+    from fabric_cli.core import fab_constant
+    from fabric_cli.utils.fab_cmd_set_utils import validate_sql_database_property
+
+    # Non-integer string
+    with pytest.raises(FabricCLIError) as exc_info:
+        validate_sql_database_property(
+            "properties.backupRetentionDays", "seven")
+    assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+    assert "backupRetentionDays" in str(exc_info.value)
+
+    # Float value
+    with pytest.raises(FabricCLIError) as exc_info:
+        validate_sql_database_property("properties.backupRetentionDays", "7.5")
+    assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+
+    # Boolean value
+    with pytest.raises(FabricCLIError) as exc_info:
+        validate_sql_database_property(
+            "properties.backupRetentionDays", "true")
+    assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+
+
+def test_validate_sql_database_property_backup_retention_days_negative_failure():
+    from fabric_cli.core import fab_constant
+    from fabric_cli.utils.fab_cmd_set_utils import validate_sql_database_property
+
+    with pytest.raises(FabricCLIError) as exc_info:
+        validate_sql_database_property("properties.backupRetentionDays", "-5")
+    assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
+
+
+def test_validate_sql_database_property_other_property_no_validation_success():
+    from fabric_cli.utils.fab_cmd_set_utils import validate_sql_database_property
+
+    # Other properties should pass without validation
+    validate_sql_database_property("properties.description", "any value")
+    validate_sql_database_property("properties.other", "some value")
+    validate_sql_database_property("displayName", "new name")

--- a/tests/test_utils/test_fab_cmd_set_utils.py
+++ b/tests/test_utils/test_fab_cmd_set_utils.py
@@ -229,7 +229,7 @@ def test_validate_sql_database_property_backup_retention_days_out_of_range_failu
     with pytest.raises(FabricCLIError) as exc_info:
         validate_sql_database_property("properties.backupRetentionDays", "0")
     assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-    assert "backupRetentionDays" in str(exc_info.value)
+    assert "backup retention days" in str(exc_info.value)
     assert "1" in str(exc_info.value)
     assert "35" in str(exc_info.value)
 
@@ -245,20 +245,13 @@ def test_validate_sql_database_property_backup_retention_days_not_integer_failur
 
     # Non-integer string
     with pytest.raises(FabricCLIError) as exc_info:
-        validate_sql_database_property(
-            "properties.backupRetentionDays", "seven")
+        validate_sql_database_property("properties.backupRetentionDays", "seven")
     assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-    assert "backupRetentionDays" in str(exc_info.value)
+    assert "backup retention days" in str(exc_info.value)
 
     # Float value
     with pytest.raises(FabricCLIError) as exc_info:
         validate_sql_database_property("properties.backupRetentionDays", "7.5")
-    assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
-
-    # Boolean value
-    with pytest.raises(FabricCLIError) as exc_info:
-        validate_sql_database_property(
-            "properties.backupRetentionDays", "true")
     assert exc_info.value.status_code == fab_constant.ERROR_INVALID_INPUT
 
 


### PR DESCRIPTION
Fixes #147.

Adds validation for the `backupRetentionDays` property on SQL databases. It ensures the value is a valid integer between 1 and 35.