### PR TITLE
fix: Enforce owner-only permissions on local files on POSIX

### DIFF
--- a/.changes/unreleased/fixed-20260618-123845.yaml
+++ b/.changes/unreleased/fixed-20260618-123845.yaml
@@ -1,0 +1,6 @@
+kind: fixed
+body: Enforce owner-only (0o600) permissions on local files on POSIX so they are no longer world-readable
+time: 2026-06-18T12:38:45Z
+custom:
+    Author: aviatcohen
+    AuthorLink: https://github.com/aviatcohen

--- a/.changes/unreleased/fixed-20260618-123845.yaml
+++ b/.changes/unreleased/fixed-20260618-123845.yaml
@@ -1,5 +1,5 @@
 kind: fixed
-body: Enforce owner-only (0o600) permissions on local files on POSIX so they are no longer world-readable
+body: Enforce owner-only permissions on local files on POSIX
 time: 2026-06-18T12:38:45Z
 custom:
     Author: aviatcohen

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -215,10 +215,6 @@ class FabAuth:
                     con.ERROR_ENCRYPTION_FAILED,
                 )
 
-        # cache.bin is created and written by msal_extensions, not the CLI, so
-        # tighten any pre-existing file (e.g. left world-readable by an older
-        # CLI version) to owner-only before it is used. Newly written caches
-        # are tightened after token acquisition in acquire_token().
         restrict_existing_file(self.cache_file)
 
         return persistence
@@ -512,9 +508,7 @@ class FabAuth:
                     f"Error in get token: {token.get('error_description')}"
                 )
                 raise FabricCLIError(
-                    ErrorMessages.Auth.access_token_error(
-                        "Something went wrong while trying to acquire a token. Please try to run `fab auth logout` and then `fab auth login` to re-login and acquire new tokens."
-                    ),
+                    ErrorMessages.Auth.token_acquisition_failed(),
                     status_code=con.ERROR_AUTHENTICATION_FAILED,
                 )
             if token is None or not token.get("access_token"):
@@ -525,10 +519,6 @@ class FabAuth:
 
             return token
         finally:
-            # MSAL writes the refreshed token cache (cache.bin) during the
-            # acquire_token_* calls above. Tighten it to owner-only afterwards,
-            # since msal_extensions does not enforce restrictive permissions on
-            # all platforms/paths (e.g. the encrypted signal file).
             restrict_existing_file(self.cache_file)
 
     def get_access_token(self, scope: list[str], interactive_renew=True) -> str | None:

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -494,7 +494,7 @@ class FabAuth:
                     scopes=scope, account=account
                 )
 
-                if token is None and interactive_renew and identity_type == "user":
+                if token is None and interactive_renew:
                     token = self._get_app().acquire_token_interactive(
                         scopes=scope,
                         prompt="select_account",

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -461,8 +461,7 @@ class FabAuth:
 
         try:
             token = None
-            env_var_token = self._get_access_token_from_env_vars_if_exist(
-                scope)
+            env_var_token = self._get_access_token_from_env_vars_if_exist(scope)
 
             identity_type = self.get_identity_type()
 

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -214,8 +214,8 @@ class FabAuth:
                     ErrorMessages.Auth.encrypted_cache_error(),
                     con.ERROR_ENCRYPTION_FAILED,
                 )
-
-        restrict_existing_file(self.cache_file)
+        finally:
+            restrict_existing_file(self.cache_file)
 
         return persistence
 

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -199,6 +199,8 @@ class FabAuth:
         return decoded_dict
 
     def _get_persistence(self):
+        from fabric_cli.utils.fab_secure_io import restrict_existing_file
+
         persistence = None
         try:
             persistence = build_encrypted_persistence(self.cache_file)
@@ -212,6 +214,12 @@ class FabAuth:
                     ErrorMessages.Auth.encrypted_cache_error(),
                     con.ERROR_ENCRYPTION_FAILED,
                 )
+
+        # cache.bin is created and written by msal_extensions, not the CLI, so
+        # tighten any pre-existing file (e.g. left world-readable by an older
+        # CLI version) to owner-only before it is used. Newly written caches
+        # are tightened after token acquisition in acquire_token().
+        restrict_existing_file(self.cache_file)
 
         return persistence
 
@@ -449,68 +457,80 @@ class FabAuth:
         Raises:
             FabricCLIError: When token acquisition fails
         """
-        token = None
-        env_var_token = self._get_access_token_from_env_vars_if_exist(scope)
+        from fabric_cli.utils.fab_secure_io import restrict_existing_file
 
-        identity_type = self.get_identity_type()
+        try:
+            token = None
+            env_var_token = self._get_access_token_from_env_vars_if_exist(
+                scope)
 
-        if identity_type == "service_principal":
-            token = self._get_app().acquire_token_for_client(scopes=scope)
+            identity_type = self.get_identity_type()
 
-        elif identity_type == "managed_identity":
-            # remove the .default from the scope
-            resource = scope[0].replace("/.default", "")
-            try:
-                token = self._get_app().acquire_token_for_client(resource=resource)
+            if identity_type == "service_principal":
+                token = self._get_app().acquire_token_for_client(scopes=scope)
 
-            except ConnectionError:
+            elif identity_type == "managed_identity":
+                # remove the .default from the scope
+                resource = scope[0].replace("/.default", "")
+                try:
+                    token = self._get_app().acquire_token_for_client(resource=resource)
+
+                except ConnectionError:
+                    raise FabricCLIError(
+                        ErrorMessages.Auth.managed_identity_connection_failed(),
+                        status_code=con.ERROR_AUTHENTICATION_FAILED,
+                    )
+                except Exception:
+                    raise FabricCLIError(
+                        ErrorMessages.Auth.managed_identity_token_failed(),
+                        status_code=con.ERROR_AUTHENTICATION_FAILED,
+                    )
+            elif env_var_token:
+                token = {
+                    "access_token": env_var_token,
+                }
+            elif identity_type == "user":
+                # Use the cache to get the token
+                accounts = self._get_app().get_accounts()
+                account = None
+                if accounts:
+                    account = accounts[0]
+                token = self._get_app().acquire_token_silent(
+                    scopes=scope, account=account
+                )
+
+                if token is None and interactive_renew and identity_type == "user":
+                    token = self._get_app().acquire_token_interactive(
+                        scopes=scope,
+                        prompt="select_account",
+                        parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
+                    )
+                    if token is not None and "id_token_claims" in token:
+                        self.set_tenant(token.get("id_token_claims")["tid"])
+
+            if token and token.get("error"):
+                fab_logger.log_debug(
+                    f"Error in get token: {token.get('error_description')}"
+                )
                 raise FabricCLIError(
-                    ErrorMessages.Auth.managed_identity_connection_failed(),
+                    ErrorMessages.Auth.access_token_error(
+                        "Something went wrong while trying to acquire a token. Please try to run `fab auth logout` and then `fab auth login` to re-login and acquire new tokens."
+                    ),
                     status_code=con.ERROR_AUTHENTICATION_FAILED,
                 )
-            except Exception:
+            if token is None or not token.get("access_token"):
                 raise FabricCLIError(
-                    ErrorMessages.Auth.managed_identity_token_failed(),
+                    ErrorMessages.Auth.access_token_error(),
                     status_code=con.ERROR_AUTHENTICATION_FAILED,
                 )
-        elif env_var_token:
-            token = {
-                "access_token": env_var_token,
-            }
-        elif identity_type == "user":
-            # Use the cache to get the token
-            accounts = self._get_app().get_accounts()
-            account = None
-            if accounts:
-                account = accounts[0]
-            token = self._get_app().acquire_token_silent(scopes=scope, account=account)
 
-            if token is None and interactive_renew and identity_type == "user":
-                token = self._get_app().acquire_token_interactive(
-                    scopes=scope,
-                    prompt="select_account",
-                    parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
-                )
-                if token is not None and "id_token_claims" in token:
-                    self.set_tenant(token.get("id_token_claims")["tid"])
-
-        if token and token.get("error"):
-            fab_logger.log_debug(
-                f"Error in get token: {token.get('error_description')}"
-            )
-            raise FabricCLIError(
-                ErrorMessages.Auth.access_token_error(
-                    "Something went wrong while trying to acquire a token. Please try to run `fab auth logout` and then `fab auth login` to re-login and acquire new tokens."
-                ),
-                status_code=con.ERROR_AUTHENTICATION_FAILED,
-            )
-        if token is None or not token.get("access_token"):
-            raise FabricCLIError(
-                ErrorMessages.Auth.access_token_error(),
-                status_code=con.ERROR_AUTHENTICATION_FAILED,
-            )
-
-        return token
+            return token
+        finally:
+            # MSAL writes the refreshed token cache (cache.bin) during the
+            # acquire_token_* calls above. Tighten it to owner-only afterwards,
+            # since msal_extensions does not enforce restrictive permissions on
+            # all platforms/paths (e.g. the encrypted signal file).
+            restrict_existing_file(self.cache_file)
 
     def get_access_token(self, scope: list[str], interactive_renew=True) -> str | None:
         """

--- a/src/fabric_cli/core/fab_logger.py
+++ b/src/fabric_cli/core/fab_logger.py
@@ -14,9 +14,9 @@ import fabric_cli.core.fab_constant as fab_constant
 import fabric_cli.core.fab_state_config as fab_state_config
 import fabric_cli.utils.fab_ui as utils_ui
 from fabric_cli.utils.fab_secure_io import (
-    chmod_if_posix,
     create_restricted_dir,
     get_restricted_file_opener,
+    restrict_existing_file,
 )
 
 _logger_instance = None  # Singleton instance
@@ -187,7 +187,7 @@ class _RestrictedRotatingFileHandler(RotatingFileHandler):
         # Use a custom opener to create the initial log file with 0o600
         super().__init__(*args, **kwargs)
         # Tighten permissions on the log file (handles pre-existing files)
-        chmod_if_posix(self.baseFilename, 0o600)
+        restrict_existing_file(self.baseFilename)
 
     def _open(self):  # type: ignore[override]
         """Override _open to use restricted permissions for new log files."""
@@ -206,8 +206,7 @@ class _RestrictedRotatingFileHandler(RotatingFileHandler):
         # base file is created. Tighten permissions on all rotated backups.
         for i in range(1, self.backupCount + 1):
             rotated_file = self.rotation_filename(f"{self.baseFilename}.{i}")
-            if os.path.exists(rotated_file):
-                chmod_if_posix(rotated_file, 0o600)
+            restrict_existing_file(rotated_file)
 
 
 def _setup_logger(file_name: str):

--- a/src/fabric_cli/errors/auth.py
+++ b/src/fabric_cli/errors/auth.py
@@ -85,6 +85,14 @@ class AuthErrors:
         return "Failed to obtain access token"
 
     @staticmethod
+    def token_acquisition_failed() -> str:
+        return (
+            "Something went wrong while trying to acquire a token. Please try to "
+            "run `fab auth logout` and then `fab auth login` to re-login and "
+            "acquire new tokens."
+        )
+
+    @staticmethod
     def jwt_decode_failed() -> str:
         return "Failed to decode JWT token"
 

--- a/src/fabric_cli/errors/auth.py
+++ b/src/fabric_cli/errors/auth.py
@@ -89,7 +89,7 @@ class AuthErrors:
         return (
             "Something went wrong while trying to acquire a token. Please try to "
             "run `fab auth logout` and then `fab auth login` to re-login and "
-            "acquire new tokens."
+            "acquire new tokens"
         )
 
     @staticmethod

--- a/src/fabric_cli/errors/auth.py
+++ b/src/fabric_cli/errors/auth.py
@@ -86,7 +86,7 @@ class AuthErrors:
 
     @staticmethod
     def token_acquisition_failed() -> str:
-        return (
+        return AuthErrors.access_token_error(
             "Something went wrong while trying to acquire a token. Please try to "
             "run `fab auth logout` and then `fab auth login` to re-login and "
             "acquire new tokens"

--- a/src/fabric_cli/utils/fab_secure_io.py
+++ b/src/fabric_cli/utils/fab_secure_io.py
@@ -58,8 +58,11 @@ def write_restricted_file(file_path: str, content: str) -> None:
     exposed through a world-readable file descriptor.
     """
     restrict_existing_file(file_path)
-    fd = os.open(file_path, os.O_WRONLY | os.O_CREAT |
-                 os.O_TRUNC, OWNER_ONLY_FILE_MODE)
+    fd = os.open(
+        file_path,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        OWNER_ONLY_FILE_MODE,
+    )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as file:
             file.write(content)

--- a/src/fabric_cli/utils/fab_secure_io.py
+++ b/src/fabric_cli/utils/fab_secure_io.py
@@ -20,7 +20,7 @@ _logger = logging.getLogger(__name__)
 IS_POSIX = os.name != "nt"
 
 # Owner read/write only (rw-------); the permission we enforce on every
-# sensitive file the CLI manages.
+# file the CLI manages.
 OWNER_ONLY_FILE_MODE = 0o600
 
 # Owner read/write/execute only (rwx------); the permission we enforce on every

--- a/src/fabric_cli/utils/fab_secure_io.py
+++ b/src/fabric_cli/utils/fab_secure_io.py
@@ -19,12 +19,19 @@ _logger = logging.getLogger(__name__)
 # True on Linux/macOS; False on Windows where POSIX permission bits are a no-op.
 IS_POSIX = os.name != "nt"
 
+# Owner read/write only (rw-------); the permission we enforce on every
+# sensitive file the CLI manages.
+OWNER_ONLY_FILE_MODE = 0o600
+
+# Owner read/write/execute only (rwx------); the permission we enforce on every
+# directory the CLI manages.
+OWNER_ONLY_DIR_MODE = 0o700
+
 
 def chmod_if_posix(path: str, mode: int) -> None:
     """Best-effort chmod on POSIX; no-op on Windows.
 
-    Logs at debug level when chmod fails (e.g. permission denied on
-    restrictive filesystems) since the user cannot act on it.
+    Logs at debug level on failure since the user cannot act on it.
     """
     if IS_POSIX:
         try:
@@ -33,25 +40,31 @@ def chmod_if_posix(path: str, mode: int) -> None:
             _logger.debug("Failed to set permissions %o on %s: %s", mode, path, e)
 
 
+def restrict_existing_file(path: str) -> None:
+    """Tighten an already-written file to owner-only access (0o600) on POSIX.
+
+    No-op on Windows or when the file does not exist. Use this for files the
+    CLI cannot create through :func:`write_restricted_file` (e.g. the MSAL
+    token cache written by ``msal_extensions``).
+    """
+    if os.path.exists(path):
+        chmod_if_posix(path, OWNER_ONLY_FILE_MODE)
+
+
 def write_restricted_file(file_path: str, content: str) -> None:
     """Write content to a file with owner-only permissions (0o600).
 
-    Handles both new file creation and tightening permissions on
-    pre-existing files from older CLI versions.  Permissions are
-    tightened *before* truncation so that sensitive content is never
-    written to a world-readable file descriptor.
+    Permissions are tightened *before* truncation so existing content is never
+    exposed through a world-readable file descriptor.
     """
-    # Tighten permissions on pre-existing files before writing, so
-    # the truncate+write never exposes new content through a permissive fd.
-    if os.path.exists(file_path):
-        chmod_if_posix(file_path, 0o600)
-    fd = os.open(file_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    restrict_existing_file(file_path)
+    fd = os.open(file_path, os.O_WRONLY | os.O_CREAT |
+                 os.O_TRUNC, OWNER_ONLY_FILE_MODE)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as file:
             file.write(content)
     except Exception:
-        # os.fdopen may fail before wrapping fd; close to avoid leak.
-        # If os.fdopen succeeded, fd is already closed by the with block.
+        # Close the fd if os.fdopen failed before wrapping it (avoids a leak).
         try:
             os.close(fd)
         except OSError:
@@ -60,22 +73,14 @@ def write_restricted_file(file_path: str, content: str) -> None:
 
 
 def get_restricted_file_opener():
-    """Return a file opener that creates files with 0o600 on POSIX, or None on Windows.
-
-    Intended for use as the ``opener`` argument to :func:`open`.  Returns
-    ``None`` on Windows so that the default opener is used.
-    """
+    """Return an ``open`` opener that creates files with 0o600 on POSIX, else None."""
     if IS_POSIX:
-        return lambda path, flags: os.open(path, flags, 0o600)
+        return lambda path, flags: os.open(path, flags, OWNER_ONLY_FILE_MODE)
     return None
 
 
 def create_restricted_dir(dir_path: str) -> None:
-    """Create a directory with owner-only permissions (0o700).
-
-    Uses exist_ok=True to avoid TOCTOU races and tightens permissions
-    on pre-existing directories from older CLI versions.
-    """
-    os.makedirs(dir_path, mode=0o700, exist_ok=True)
+    """Create (or tighten) a directory with owner-only permissions (0o700)."""
+    os.makedirs(dir_path, mode=OWNER_ONLY_DIR_MODE, exist_ok=True)
     # Enforce permissions on pre-existing directories from older versions
-    chmod_if_posix(dir_path, 0o700)
+    chmod_if_posix(dir_path, OWNER_ONLY_DIR_MODE)

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -878,7 +878,7 @@ def test_get_access_token_token_error(monkeypatch):
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
     assert (
         exc_info.value.message
-        == ErrorMessages.Auth.token_acquisition_failed().rstrip(".")
+        == ErrorMessages.Auth.token_acquisition_failed()
     )
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
 

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -21,6 +21,7 @@ from cryptography.x509.oid import NameOID
 from fabric_cli.core import fab_constant as con
 from fabric_cli.core.fab_auth import FabAuth
 from fabric_cli.core.fab_exceptions import FabricCLIError
+from fabric_cli.errors import ErrorMessages
 
 
 @pytest.fixture(autouse=True)
@@ -877,7 +878,8 @@ def test_get_access_token_token_error(monkeypatch):
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
     assert (
         exc_info.value.message
-        == "Failed to get access token: Something went wrong while trying to acquire a token. Please try to run `fab auth logout` and then `fab auth login` to re-login and acquire new tokens"
+        == "Failed to get access token: "
+        + ErrorMessages.Auth.token_acquisition_failed().rstrip(".")
     )
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
 

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -4,6 +4,7 @@
 import datetime
 import json
 import os
+import stat
 import tempfile
 import uuid
 from unittest.mock import patch
@@ -349,6 +350,56 @@ def test_get_access_token_user_silent_success():
         token = auth.get_access_token([con.SCOPE_FABRIC_DEFAULT])
         assert token == expected_token
         set_tenant_spy.assert_not_called()
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX permission bits are a no-op on Windows"
+)
+def test_acquire_token_tightens_cache_file_permissions_success(tmp_path):
+
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+
+    cache_file = os.path.join(str(tmp_path), "cache.bin")
+    with open(cache_file, "w", encoding="utf-8") as handle:
+        handle.write("serialized-token-cache")
+    os.chmod(cache_file, 0o644)
+    auth.cache_file = cache_file
+
+    with patch.object(auth, "app", wraps=auth.app) as mock_app:
+        mock_app.acquire_token_silent.return_value = {
+            "access_token": "silent_token"}
+        auth.get_access_token([con.SCOPE_FABRIC_DEFAULT])
+
+    mode = stat.S_IMODE(os.stat(cache_file).st_mode)
+    assert mode == 0o600
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX permission bits are a no-op on Windows"
+)
+def test_acquire_token_tightens_cache_file_on_error_success(tmp_path):
+    # Even when token acquisition fails, the cache file written by MSAL during
+    # the attempt must still be tightened (finally block).
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+
+    cache_file = os.path.join(str(tmp_path), "cache.bin")
+    with open(cache_file, "w", encoding="utf-8") as handle:
+        handle.write("serialized-token-cache")
+    os.chmod(cache_file, 0o644)
+    auth.cache_file = cache_file
+
+    with patch.object(auth, "app", wraps=auth.app) as mock_app:
+        mock_app.acquire_token_silent.return_value = None
+        mock_app.acquire_token_interactive.return_value = {
+            "error": "token acquisition failed"
+        }
+        with pytest.raises(FabricCLIError):
+            auth.get_access_token([con.SCOPE_FABRIC_DEFAULT])
+
+    mode = stat.S_IMODE(os.stat(cache_file).st_mode)
+    assert mode == 0o600
 
 
 def test_get_access_token_user_interactive_error_response_failure():

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -368,8 +368,7 @@ def test_acquire_token_tightens_cache_file_permissions_success(tmp_path):
     auth.cache_file = cache_file
 
     with patch.object(auth, "app", wraps=auth.app) as mock_app:
-        mock_app.acquire_token_silent.return_value = {
-            "access_token": "silent_token"}
+        mock_app.acquire_token_silent.return_value = {"access_token": "silent_token"}
         auth.get_access_token([con.SCOPE_FABRIC_DEFAULT])
 
     mode = stat.S_IMODE(os.stat(cache_file).st_mode)

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -878,8 +878,7 @@ def test_get_access_token_token_error(monkeypatch):
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
     assert (
         exc_info.value.message
-        == "Failed to get access token: "
-        + ErrorMessages.Auth.token_acquisition_failed().rstrip(".")
+        == ErrorMessages.Auth.token_acquisition_failed().rstrip(".")
     )
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
 

--- a/tests/test_utils/test_fab_secure_io.py
+++ b/tests/test_utils/test_fab_secure_io.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+import stat
+import tempfile
+
+import pytest
+
+from fabric_cli.utils import fab_secure_io
+from fabric_cli.utils.fab_secure_io import (
+    OWNER_ONLY_FILE_MODE,
+    restrict_existing_file,
+    write_restricted_file,
+)
+
+# These permission assertions only make sense on POSIX, where chmod bits are
+# enforced. On Windows the helpers are intentional no-ops (ACL-based).
+posix_only = pytest.mark.skipif(
+    not fab_secure_io.IS_POSIX, reason="POSIX permission bits are a no-op on Windows"
+)
+
+
+def _mode(path: str) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+# ---------------------------------------------------------------------------
+# restrict_existing_file
+# ---------------------------------------------------------------------------
+
+
+@posix_only
+def test_restrict_existing_file_tightens_world_readable_file_success():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "auth.json")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("secret")
+        os.chmod(path, 0o644)
+
+        restrict_existing_file(path)
+
+        assert _mode(path) == OWNER_ONLY_FILE_MODE
+
+
+@posix_only
+def test_restrict_existing_file_keeps_owner_read_write_success():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "auth.json")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("secret")
+        os.chmod(path, 0o644)
+
+        restrict_existing_file(path)
+
+        mode = _mode(path)
+        # Owner can still read and write (so MSAL can reopen it)...
+        assert mode & stat.S_IRUSR
+        assert mode & stat.S_IWUSR
+        # ...but group and others have no access.
+        assert not mode & (stat.S_IRWXG | stat.S_IRWXO)
+
+
+def test_restrict_existing_file_missing_file_is_noop_success():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "does-not-exist.json")
+        # Should not raise.
+        restrict_existing_file(path)
+        assert not os.path.exists(path)
+
+
+# ---------------------------------------------------------------------------
+# write_restricted_file
+# ---------------------------------------------------------------------------
+
+
+@posix_only
+def test_write_restricted_file_creates_owner_only_file_success():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "config.json")
+        write_restricted_file(path, '{"key": "value"}')
+
+        assert _mode(path) == OWNER_ONLY_FILE_MODE
+        with open(path, "r", encoding="utf-8") as handle:
+            assert handle.read() == '{"key": "value"}'
+
+
+@posix_only
+def test_write_restricted_file_tightens_preexisting_file_success():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "config.json")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("old")
+        os.chmod(path, 0o644)
+
+        write_restricted_file(path, "new")
+
+        assert _mode(path) == OWNER_ONLY_FILE_MODE
+        with open(path, "r", encoding="utf-8") as handle:
+            assert handle.read() == "new"


### PR DESCRIPTION
# 📥 Pull Request

<!--
Pull request title must follows the [Conventional Commits](https://www.conventionalcommits.org/) format (`type(scope): subject`).

**type**: Must be one of the following:

- `feat`: A new feature
- `fix`: A bug fix
- `docs`: Documentation only changes
- `style`: Changes that do not affect the meaning of the code (e.g., formatting)
- `refactor`: A code change that neither fixes a bug nor adds a feature
- `perf`: A code change that improves performance
- `test`: Adding missing tests or correcting existing tests
- `chore`: Changes to the build process or auxiliary tools
- `build`: Changes that affect the build system or external dependencies
- `ci`: Changes to CI configuration files and scripts
- `revert`: Reverts a previous commit
-->

## ✨ Description of new changes
This pull request enforces strict owner-only (0o600) permissions on all sensitive files managed by the CLI on POSIX systems, ensuring that files written to disk are never world-readable. It introduces a new utility function to tighten permissions on any pre-existing files, updates file and directory creation to consistently use secure permissions, and adds comprehensive tests to verify these behaviors. These changes significantly improve the security posture of the CLI regarding file access.

**Security and Permissions Enforcement**

* Added `restrict_existing_file` utility to ensure files are tightened to owner-only permissions (0o600) on POSIX, and refactored code to use this for all sensitive files, including authentication caches and log files. (`src/fabric_cli/utils/fab_secure_io.py`, `src/fabric_cli/core/fab_auth.py`, `src/fabric_cli/core/fab_logger.py`) [[1]](diffhunk://#diff-05fa51353f84b61aaf44fff344fc292b5cde56e41445f9c32f62f245d2a3a11fR43-R67) [[2]](diffhunk://#diff-51ff78a5157b761c8e6dd8733ba42ed4921d3f4005f29cfa7c6f285dcafb4110R202-R203) [[3]](diffhunk://#diff-51ff78a5157b761c8e6dd8733ba42ed4921d3f4005f29cfa7c6f285dcafb4110R218-R223) [[4]](diffhunk://#diff-51ff78a5157b761c8e6dd8733ba42ed4921d3f4005f29cfa7c6f285dcafb4110R460-R465) [[5]](diffhunk://#diff-51ff78a5157b761c8e6dd8733ba42ed4921d3f4005f29cfa7c6f285dcafb4110R528-R533) [[6]](diffhunk://#diff-75a496cdd42e6162fbd1837c1380a083c6cb02b0812312ee42c1d69b7397a59eL17-R19) [[7]](diffhunk://#diff-75a496cdd42e6162fbd1837c1380a083c6cb02b0812312ee42c1d69b7397a59eL190-R190) [[8]](diffhunk://#diff-75a496cdd42e6162fbd1837c1380a083c6cb02b0812312ee42c1d69b7397a59eL209-R209)
* Defined constants `OWNER_ONLY_FILE_MODE` (0o600) and `OWNER_ONLY_DIR_MODE` (0o700) for consistent permission use across the codebase. (`src/fabric_cli/utils/fab_secure_io.py`)
* Updated directory and file creation helpers to use these constants and improved docstrings for clarity. (`src/fabric_cli/utils/fab_secure_io.py`)

**Testing**

* Added new tests to verify that sensitive files are always tightened to owner-only permissions, including after successful or failed token acquisition and for pre-existing files. (`tests/test_core/test_fab_auth.py`, `tests/test_utils/test_fab_secure_io.py`) [[1]](diffhunk://#diff-7f0a6c2d7925b32e49973d3b96bc008fd554631003bd55974f3f207e2c2d7327R355-R404) [[2]](diffhunk://#diff-25eb7f0d39d521e5cabd75c58116ab08de48497d68721e5e71926f65f521b58cR1-R100)

**Changelog**

* Added a changelog entry describing the fix for enforcing owner-only permissions on local files so they are no longer world-readable. (`.changes/unreleased/fixed-20260618-123845.yaml`)
<!--
Provide a clear and concise description of the changes.

- **Summary**: What is the change and what issue does it fix?
- **Context**: Why is this change needed? What is the motivation?
- **Dependencies**: Are there any dependencies required for this change?
-->