### PR TITLE
ci: improve AI issue triager routing and prompts

### DIFF
--- a/.github/prompts/bug-triage.prompt.yml
+++ b/.github/prompts/bug-triage.prompt.yml
@@ -166,23 +166,30 @@ messages:
 
       ## Re-triage
 
-      If the input starts with `[RE-TRIAGE]`, this issue was previously assessed and the author has responded with additional information. Focus your assessment on the new information provided. Do not repeat your prior analysis — evaluate whether the author's response resolves the gaps or changes the assessment.
+      If the input contains `[RE-TRIAGE]`, this issue was previously assessed and the author has responded with additional information. Focus your assessment on the new information provided. Do not repeat your prior analysis — evaluate whether the author's response resolves the gaps or changes the assessment.
 
       ## Response Format
+
+      The user input begins with a line in the form `Issue author: @handle` that identifies the issue author. Whenever a Next Steps line addresses the author, replace `{issue_author}` with that exact handle, including the leading `@` (for example `@octocat`). Never output the literal text `{issue_author}`.
 
       Start your response with a markdown header in this exact format:
       ### AI Assessment: <category>
 
       Then provide your analysis in clearly structured sections.
 
-      End every response with a **Next Steps** section using exactly one of these:
-      - `**⏳ Awaiting author feedback** — @{issue_author}, please provide the details listed above.` (when category is "Needs Author Feedback")
-      - `**🔔 Escalated to team** — This issue requires team review and has been flagged for attention.` (when category is "Potential Bug", "Needs Team Review", or any issue that requires human investigation)
-      - `**✅ No action needed** — This issue has been triaged. The team will prioritize accordingly.` (only when category is "Likely Misconfiguration" and you provided a complete resolution)
+      End every response with a **Next Steps** section containing exactly one of the lines below, chosen by category. Output the chosen line as normal markdown bold text — do not wrap it in backticks or a code block, and do not include the parenthetical condition:
 
-      After the Next Steps section, always append this footer on a new line:
-      `---`
-      `> 💡 If this issue requires the team's attention and was not escalated, you can tag @microsoft/fabric-cli-dev to notify the team.`
+      - **⏳ Awaiting author feedback** — {issue_author}, please provide the details listed above. (when category is "Needs Author Feedback")
+
+      - **🔔 Escalated to team** — This issue requires team review and has been flagged for attention. (when category is "Potential Bug", "Needs Team Review", or any issue that requires human investigation)
+
+      - **✅ No action needed** — This issue has been triaged. The team will prioritize accordingly. (only when category is "Likely Misconfiguration" and you provided a complete resolution)
+
+      After the Next Steps section, always append this exact footer, starting on a new line. Output it as normal markdown (a horizontal rule followed by a blockquote), not as code:
+
+      ---
+
+      > 💡 If this issue requires the team's attention and was not escalated, you can tag @microsoft/fabric-cli-dev to notify the team.
   - role: user
     content: '{{input}}'
 model: openai/gpt-4.1

--- a/.github/prompts/documentation-triage.prompt.yml
+++ b/.github/prompts/documentation-triage.prompt.yml
@@ -1,15 +1,15 @@
 messages:
   - role: system
     content: >+
-      You are a product-minded engineer evaluating feature requests for **Microsoft Fabric CLI** (`fab`), an open-source Python CLI for Microsoft Fabric.
+      You are a documentation specialist for **Microsoft Fabric CLI** (`fab`), an open-source Python CLI for Microsoft Fabric. You triage documentation issues — reports of missing, unclear, outdated, or incorrect documentation.
 
       ## About the CLI
 
       - Python 3.10-3.13, argparse-based command parsing, pip-installable (`pip install ms-fabric-cli`).
       - Models Fabric as a filesystem-like hierarchy with dot-suffix entity names:
-        `/Workspace1.Workspace/FolderA.Folder/SemanticModel1.SemanticModel`
-      - Key design principles: path-first UX, stable verbs (`ls`, `get`, `set`, `rm`), consistent flags across item types, backward compatibility.
-      - Supports nested folders, hidden entities (`.capacities`, `.gateways`), interactive and command-line modes.
+        `/Workspace1.Workspace/FolderA.Folder/Item1.SemanticModel`
+      - Supports nested folders (up to ~10 levels), hidden entities (`.capacities`, `.gateways`, `.sparkpools`).
+      - Two modes: **interactive** (REPL-like, no `fab` prefix needed) and **command-line** (single process, `fab <command>`).
       - Config stored in `~/.config/fab/` (config.json, auth.json, cache.bin)
       - Official CLI docs: https://microsoft.github.io/fabric-cli
       - Fabric REST API docs: https://learn.microsoft.com/en-us/rest/api/fabric/
@@ -40,15 +40,15 @@ messages:
       - Auth examples: https://microsoft.github.io/fabric-cli/examples/auth_examples/
       - Item examples: https://microsoft.github.io/fabric-cli/examples/item_examples/
 
-      ## Standards & Best Practices (use when evaluating feasibility and design)
+      ## Standards & Best Practices (use when relevant)
 
-      - **CLI conventions**: POSIX Utility Conventions (IEEE Std 1003.1), GNU Argument Syntax, 12-Factor CLI. Use to evaluate whether a proposed command/flag design follows established patterns.
-      - **Python packaging**: PEP 440 (versioning), PEP 517/518 (build system), semver. Use to evaluate version or distribution-related requests.
-      - **HTTP/REST**: RFC 7231 (HTTP semantics), Microsoft REST API Guidelines. Use to evaluate whether a Fabric API supports the proposed feature.
-      - **Backward compatibility**: semver, Python deprecation conventions (PEP 387). Use to evaluate breaking change risk.
-      - **Auth**: OAuth 2.0 (RFC 6749), MSAL best practices. Use to evaluate auth-related feature requests.
+      - **Python packaging**: PEP 440 (versioning), PEP 508 (dependency specifiers). Reference when answering install or version questions.
+      - **CLI conventions**: POSIX Utility Conventions, GNU Argument Syntax. Reference when explaining flag behavior, exit codes, or argument patterns.
+      - **HTTP/REST**: RFC 7231 (HTTP semantics), Microsoft REST API Guidelines. Reference when explaining API responses or error codes.
+      - **Auth**: OAuth 2.0 (RFC 6749), OpenID Connect, MSAL best practices. Reference when explaining auth flows or token issues.
+      - **Data formats**: RFC 8259 (JSON), YAML 1.2 spec. Reference when explaining config or output format questions.
 
-      When citing a standard, mention it briefly (e.g., "this aligns with POSIX conventions for...") — do not explain the standard itself.
+      When citing a standard, mention it briefly (e.g., "per POSIX conventions, exit code 0 means...") — do not explain the standard itself.
 
       ## Codebase Reference
 
@@ -137,30 +137,27 @@ messages:
 
       ## Your Task
 
-      Evaluate the feature request. Focus on what matters — skip dimensions that are clearly fine:
-      - Only comment on alignment, backward compatibility, or feasibility if there is a concern.
-      - Highlight value and community implementability only if noteworthy (strong value or clearly suitable for community).
-      - If the request is straightforward and well-scoped, keep the assessment brief.
+      Assess a documentation issue — a report that the docs are missing, unclear, outdated, incorrect, or hard to find. Be precise and concise:
+      - Identify exactly what the documentation gap is and which page(s) it affects (cite the relevant CLI Documentation Pages above).
+      - If the topic is already documented, point to the exact page so the issue can be closed.
+      - If a real gap exists, describe the specific change needed (which page, what content) so a contributor or the team can act on it.
+      - Verify any CLI behavior you describe against the Codebase Reference above. Do not document flags, commands, or behavior that does not exist.
 
       ## Assessment Categories
 
       Use exactly one of these in your assessment header:
-      - **Valuable Enhancement** — The feature provides clear value, aligns with CLI design, and should be prioritized by the team.
-      - **Help Wanted** — The feature is valuable and well-scoped enough for community contribution. Provide implementation guidance.
-      - **Needs Author Feedback** — The request is unclear, lacks enough detail to evaluate, or needs clarification on scope/use case. Specify exactly what is needed.
-      - **Needs Discussion** — The feature has merit but raises design questions, scope concerns, or trade-offs that need team input.
-      - **Needs Team Review** — The feature is too complex, touches core architecture, or requires team expertise to evaluate properly. Escalate to the team.
-      - **Out of Scope** — The feature doesn't align with the CLI's purpose, duplicates existing functionality, or is better served by other tools (Fabric portal, REST API directly, PowerShell).
+      - **Answered** — The information the author is looking for is already covered by existing documentation. Provide the exact link(s); no doc change is needed.
+      - **Help Wanted** — There is a genuine, well-scoped documentation gap that a community contributor could fix. Describe the specific page and content to add or correct.
+      - **Needs Author Feedback** — The report is unclear or incomplete (e.g., does not say which page or what is wrong). Specify exactly what is needed.
+      - **Needs Team Review** — The doc change requires internal knowledge, touches sensitive areas (auth, security), describes undocumented or roadmap behavior, or is a large/structural docs effort that only the team can scope. Escalate to the team.
 
       ## Response Guidelines
 
       - Be concise and professional. You represent the Fabric CLI project.
-      - Write like an expert — short sentences, no filler, no pleasantries.
-      - Only highlight what is notable: strong value, concerns, blockers, or implementation guidance. Skip dimensions that are clearly fine.
-      - Do not repeat the feature description back to the requester.
-      - If "Help Wanted", give a concrete starting point (directory, similar command, relevant API).
-      - If "Out of Scope", state why and suggest an alternative — nothing more.
-      - Do not invent CLI flags, commands, or features not listed above. If unsure, direct to official docs.
+      - Write like an expert technical writer — short sentences, no filler, no pleasantries.
+      - Always cite the specific documentation page(s) involved by their URL.
+      - Do not repeat the issue back to the author.
+      - Do not invent CLI flags, commands, or features not listed in the Codebase Reference above.
       - Keep the response to **2–4 short paragraphs**. No bullet-heavy walls of text.
 
       ## Re-triage
@@ -180,13 +177,11 @@ messages:
 
       - **⏳ Awaiting author feedback** — {issue_author}, please provide the details listed above. (when category is "Needs Author Feedback")
 
-      - **🔔 Escalated to team** — This issue requires team review and has been flagged for attention. (when category is "Needs Team Review" or "Needs Discussion")
+      - **🔔 Escalated to team** — This issue requires team review and has been flagged for attention. (when category is "Needs Team Review")
 
-      - **📋 Backlog candidate** — This enhancement has been triaged and will be considered for the team's backlog. (when category is "Valuable Enhancement")
+      - **🤝 Community contribution welcome** — This documentation update is well-scoped for a community contributor. See guidance above. (when category is "Help Wanted")
 
-      - **🤝 Community contribution welcome** — This feature is well-scoped for a community contributor. See implementation guidance above. (when category is "Help Wanted")
-
-      - **✅ No action needed** — This request falls outside the CLI's scope. (when category is "Out of Scope")
+      - **✅ No action needed** — This is already covered by existing documentation. If you need further help, feel free to follow up. (when category is "Answered")
 
       After the Next Steps section, always append this exact footer, starting on a new line. Output it as normal markdown (a horizontal rule followed by a blockquote), not as code:
 

--- a/.github/prompts/question-triage.prompt.yml
+++ b/.github/prompts/question-triage.prompt.yml
@@ -162,23 +162,30 @@ messages:
 
       ## Re-triage
 
-      If the input starts with `[RE-TRIAGE]`, this issue was previously assessed and the author has responded with additional information. Focus your assessment on the new information provided. Do not repeat your prior analysis — evaluate whether the author's response resolves the gaps or changes the assessment.
+      If the input contains `[RE-TRIAGE]`, this issue was previously assessed and the author has responded with additional information. Focus your assessment on the new information provided. Do not repeat your prior analysis — evaluate whether the author's response resolves the gaps or changes the assessment.
 
       ## Response Format
+
+      The user input begins with a line in the form `Issue author: @handle` that identifies the issue author. Whenever a Next Steps line addresses the author, replace `{issue_author}` with that exact handle, including the leading `@` (for example `@octocat`). Never output the literal text `{issue_author}`.
 
       Start your response with a markdown header in this exact format:
       ### AI Assessment: <category>
 
       Then provide your answer in clearly structured sections.
 
-      End every response with a **Next Steps** section using exactly one of these:
-      - `**⏳ Awaiting author feedback** — @{issue_author}, please provide the details listed above.` (when category is "Requires Additional Details")
-      - `**🔔 Escalated to team** — This issue requires team review and has been flagged for attention.` (when category is "Needs Team Review")
-      - `**✅ No action needed** — This question has been answered. If you need further help, feel free to follow up.` (when category is "Answered" or "Redirect to Docs")
+      End every response with a **Next Steps** section containing exactly one of the lines below, chosen by category. Output the chosen line as normal markdown bold text — do not wrap it in backticks or a code block, and do not include the parenthetical condition:
 
-      After the Next Steps section, always append this footer on a new line:
-      `---`
-      `> 💡 If this issue requires the team's attention and was not escalated, you can tag @microsoft/fabric-cli-dev to notify the team.`
+      - **⏳ Awaiting author feedback** — {issue_author}, please provide the details listed above. (when category is "Requires Additional Details")
+
+      - **🔔 Escalated to team** — This issue requires team review and has been flagged for attention. (when category is "Needs Team Review")
+
+      - **✅ No action needed** — This question has been answered. If you need further help, feel free to follow up. (when category is "Answered" or "Redirect to Docs")
+
+      After the Next Steps section, always append this exact footer, starting on a new line. Output it as normal markdown (a horizontal rule followed by a blockquote), not as code:
+
+      ---
+
+      > 💡 If this issue requires the team's attention and was not escalated, you can tag @microsoft/fabric-cli-dev to notify the team.
   - role: user
     content: '{{input}}'
 model: openai/gpt-4.1

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -79,7 +79,13 @@ jobs:
               }
             }
 
+            // Prepend the author handle so prompts can address the author reliably
+            // (the AI model only receives issue_body as input).
+            const authorHandle = issue.user.login;
+            issueBody = `Issue author: @${authorHandle}\n\n${issueBody}`;
+
             core.setOutput('number', issue.number);
+            core.setOutput('author', authorHandle);
             core.setOutput('body', issueBody);
             core.setOutput('title', issue.title);
             core.setOutput('html_url', issue.html_url);
@@ -97,7 +103,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           ai_review_label: 'needs triage'
           prompts_directory: '.github/prompts'
-          labels_to_prompts_mapping: 'bug,bug-triage.prompt.yml|enhancement,feature-triage.prompt.yml|question,question-triage.prompt.yml'
+          labels_to_prompts_mapping: 'bug,bug-triage.prompt.yml|enhancement,feature-triage.prompt.yml|question,question-triage.prompt.yml|documentation,documentation-triage.prompt.yml'
           model: 'openai/gpt-4.1'
           max_tokens: 2000
           suppress_comments: ${{ env.SUPPRESS_COMMENTS }}
@@ -123,28 +129,41 @@ jobs:
             let addHelpWanted = false;
             let needsAuthorFeedback = false;
             let canAutoClose = false;
+            let surfaceToTeam = false;
+            let closeReason = 'completed';
 
             for (const assessment of assessments) {
               const label = (assessment.assessmentLabel || '').toLowerCase();
 
-              // Check if the assessment requires human review
-              if (label.includes('needs team review') || label.includes('needs maintainer input') || label.includes('potential bug') || label.includes('needs discussion')) {
+              // Requires human investigation → escalate with an @mention.
+              if (label.includes('needs team review') || label.includes('potential bug') || label.includes('needs discussion')) {
                 needsHumanReview = true;
               }
 
-              // Check if feature should be tagged as help wanted
+              // Valuable enhancement → surface for backlog filtering (no @mention spam).
+              if (label.includes('valuable enhancement')) {
+                surfaceToTeam = true;
+              }
+
+              // Suitable for community contribution.
               if (label.includes('help wanted')) {
                 addHelpWanted = true;
               }
 
-              // Check if more information is needed from the issue author
+              // More information is needed from the issue author.
               if (label.includes('needs author feedback') || label.includes('requires additional details')) {
                 needsAuthorFeedback = true;
               }
 
-              // Check if the AI fully resolved the issue (answered question, explained misconfiguration, redirected to docs)
+              // The AI fully resolved the issue (answered, misconfiguration, redirected to docs).
               if (label.includes('answered') || label.includes('likely misconfiguration') || label.includes('redirect to docs')) {
                 canAutoClose = true;
+              }
+
+              // Out of scope → close as "not planned" rather than "completed".
+              if (label.includes('out of scope')) {
+                canAutoClose = true;
+                closeReason = 'not_planned';
               }
 
               // Log for job summary
@@ -155,7 +174,7 @@ jobs:
             if (suppressLabels) {
               core.info('Labels suppressed — logging decisions only.');
               core.exportVariable('LABEL_DECISIONS', JSON.stringify({
-                needsHumanReview, addHelpWanted, needsAuthorFeedback, canAutoClose,
+                needsHumanReview, addHelpWanted, needsAuthorFeedback, canAutoClose, surfaceToTeam, closeReason,
                 assessmentLabels: assessments.map(a => a.assessmentLabel),
               }));
               return;
@@ -172,20 +191,20 @@ jobs:
               core.info('Added "help wanted" label based on AI assessment.');
             }
 
-            // If AI fully handled the issue without needing team review
-            if (!needsHumanReview) {
-              // Auto-close if AI fully resolved (answered, misconfiguration, redirected)
-              if (canAutoClose && !needsAuthorFeedback && !addHelpWanted) {
-                await github.rest.issues.update({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                  state: 'closed',
-                  state_reason: 'completed'
-                });
-                core.info('Auto-closed issue — AI fully resolved it.');
-              }
-            } else {
+            // If more info is needed, mirror the '/needinfo' policy: add 'needs author
+            // feedback' so the policy automation re-triages automatically when the author
+            // replies (it watches for that label). 'needs triage' is removed below.
+            if (needsAuthorFeedback) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: ['needs author feedback']
+              });
+              core.info('Added "needs author feedback" — awaiting author response.');
+            }
+
+            if (needsHumanReview) {
               // Add consolidated label for easy filtering of all issues needing team attention
               await github.rest.issues.addLabels({
                 owner,
@@ -202,9 +221,30 @@ jobs:
                 body: '🔔 @microsoft/fabric-cli-dev — This issue has been flagged by AI triage as requiring team attention. Please review the assessment above.'
               });
               core.info('Escalated to team.');
+            } else if (surfaceToTeam) {
+              // Valuable enhancement → label for backlog filtering, but no @mention spam.
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: ['ai:needs team attention']
+              });
+              core.info('Surfaced valuable enhancement for team backlog review.');
+            } else if (canAutoClose && !needsAuthorFeedback && !addHelpWanted) {
+              // Auto-close if AI fully resolved (answered, misconfiguration, redirected, out of scope)
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                state: 'closed',
+                state_reason: closeReason
+              });
+              core.info(`Auto-closed issue (${closeReason}) — AI fully resolved it.`);
             }
 
-            // Always remove 'needs triage' — triage is complete regardless of outcome
+            // Always remove 'needs triage' — triage is complete regardless of outcome.
+            // When awaiting author feedback this mirrors '/needinfo' (drop 'needs triage',
+            // keep 'needs author feedback'); the policy re-adds 'needs triage' on reply.
             try {
               await github.rest.issues.removeLabel({
                 owner,
@@ -251,11 +291,11 @@ jobs:
               summary += `| Decision | Value |\n|----------|-------|\n`;
               summary += `| AI assessment labels | ${(ld.assessmentLabels || []).map(l => '`' + l + '`').join(', ')} |\n`;
               summary += `| Would add \`help wanted\` | ${ld.addHelpWanted ? '✅ Yes' : '❌ No'} |\n`;
-              summary += `| Would add \`ai:needs team attention\` | ${ld.needsHumanReview ? '✅ Yes' : '❌ No'} |\n`;
-              summary += `| Would request author feedback | ${ld.needsAuthorFeedback ? '✅ Yes' : '❌ No'} |\n`;
-              summary += `| Would remove \`needs triage\` | ${!ld.needsHumanReview ? '✅ Yes' : '❌ No'} |\n`;
-              summary += `| Would auto-close | ${ld.canAutoClose && !ld.needsAuthorFeedback && !ld.addHelpWanted ? '✅ Yes' : '❌ No'} |\n`;
-              summary += `| Would notify team | ${ld.needsHumanReview ? '✅ Yes' : '❌ No'} |\n\n`;
+              summary += `| Would add \`needs author feedback\` | ${ld.needsAuthorFeedback ? '✅ Yes' : '❌ No'} |\n`;
+              summary += `| Would add \`ai:needs team attention\` | ${(ld.needsHumanReview || ld.surfaceToTeam) ? '✅ Yes' : '❌ No'} |\n`;
+              summary += `| Would auto-close | ${ld.canAutoClose && !ld.needsAuthorFeedback && !ld.addHelpWanted && !ld.needsHumanReview && !ld.surfaceToTeam ? '✅ Yes (' + (ld.closeReason || 'completed') + ')' : '❌ No'} |\n`;
+              summary += `| Would notify team (@mention) | ${ld.needsHumanReview ? '✅ Yes' : '❌ No'} |\n`;
+              summary += `| Would remove \`needs triage\` | ✅ Yes |\n\n`;
             }
 
             summary += `---\n\n`;


### PR DESCRIPTION
## Summary

Fixes several gaps found while reviewing recent triaged issues, triager runs, and prompt outputs. All changes are scoped to `.github/` triage infra (workflow + prompt YAMLs); no CLI source or tests are touched.

## Changes

**1. Fixed the "documentation" black hole**
- New `.github/prompts/documentation-triage.prompt.yml` and a `documentation` entry in the workflow's `labels_to_prompts_mapping`. Documentation issues previously had no prompt mapping, so they kept `needs triage` forever with no AI comment. Its categories (Answered, Help Wanted, Needs Author Feedback, Needs Team Review) route through the **existing** post-processing keywords/labels — no new labels required.

**2. Repaired the broken author-feedback loop**
- `Needs Author Feedback` / `Requires Additional Details` now applies the `needs author feedback` label (mirroring the `/needinfo` command), so `resourceManagement.yml` automatically re-triages when the author replies. Previously the loop never fired because the AI path never added that label.

**3. Fixed `@{issue_author}` never being substituted**
- The "Resolve issue details" step prepends `Issue author: @handle` to the AI input, and all prompts now substitute that handle for `{issue_author}` instead of emitting the literal placeholder. Because the handle is prepended ahead of any `[RE-TRIAGE]` marker, re-triage detection changed from "starts with" to "contains".

**4. Removed literal backticks** around the Next Steps and footer lines in all prompts, so they render as markdown bold/blockquote rather than inline code.

**5. Closed post-processing gaps**
- `Valuable Enhancement` → adds `ai:needs team attention` for backlog filtering (no `@mention` spam).
- `Out of Scope` → auto-closes as `not_planned` (via a new `closeReason`).
- Removed the dead `needs maintainer input` keyword and updated the triage summary table to match.

## Verification
- All prompt YAMLs, the workflow, and the policy file parse cleanly (`yaml.safe_load`).
- Routing re-checked end-to-end: every new/changed assessment category maps to an existing post-processing branch and label.

> [!NOTE]
> The branch name is `ayeshurun/dev-alonyeshurun-improve-ai-triager` rather than the requested `dev/alonyeshurun/improve-ai-triager` — the rename tooling slugifies slashes and namespaces under the handle. Happy to recreate the branch if the exact format is required.