### PR TITLE
feat: prepare Python 3.14 support

### DIFF
--- a/.changes/unreleased/added-20260630-143000.yaml
+++ b/.changes/unreleased/added-20260630-143000.yaml
@@ -1,0 +1,6 @@
+kind: added
+body: Add Python 3.14 support to package metadata, dependencies, and installation documentation
+time: 2026-06-30T14:30:00Z
+custom:
+    Author: nkwork9999
+    AuthorLink: https://github.com/nkwork9999

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This document provides guidance for AI agents assisting with the [Microsoft Fabr
 The Fabric CLI is a file-system-inspired command-line interface that lets users explore, automate, and script their Microsoft Fabric environment. Key characteristics:
 
 - **Installation**: `pip install ms-fabric-cli`
-- **Python versions**: 3.10, 3.11, 3.12, 3.13
+- **Python versions**: 3.10, 3.11, 3.12, 3.13, 3.14
 - **Platforms**: Windows, macOS, Linux
 - **Shells**: PowerShell, Bash, Zsh, cmd
 - **Modes**: Interactive (REPL) and command-line (scripting)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Navigate Microsoft Fabric like your local file system with intuitive commands:
 ## 📦 Installation
 
 ### Prerequisites
-- **Python 3.10, 3.11, 3.12, or 3.13**
+- **Python 3.10, 3.11, 3.12, 3.13, or 3.14**
 - A **Microsoft Fabric** account with access to your tenant/workspaces.
 
 ### Install via pip

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Get powerful control over your Fabric resources:
 
 ### What you need
 
-- Python 3.10, 3.11, 3.12 or 3.13
+- Python 3.10, 3.11, 3.12, 3.13 or 3.14
 - `python` in your `PATH` environment variable
 
 Check if Python is ready:
@@ -181,6 +181,5 @@ Add Fabric CLI to GitHub Actions, Azure Pipelines, and other DevOps tools. The s
 
 - Contact your Microsoft account manager
 - Open a ticket with the [Fabric Support Team](https://support.fabric.microsoft.com/)
-
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,19 +5,20 @@ description = "Command-line tool for Microsoft Fabric"
 readme = "README.md"
 dynamic = ["version"]
 license = "MIT"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "msal[broker]>=1.34,<2 ; platform_system != 'Linux'",
-    "msal>=1.34,<2",
+    "msal[broker]>=1.35,<2 ; platform_system != 'Linux'",
+    "msal>=1.35,<2",
     "msal_extensions",
     "azure-core>=1.29.0",
     "questionary",


### PR DESCRIPTION
- Related to #236

## Summary
- Remove the Python upper bound from the Fabric CLI package metadata
- Add the Python 3.14 classifier
- Bump the minimum `msal` and `msal[broker]` versions to `1.35`, the first version called out in #236 as supporting Python 3.14
- Update installation documentation and AI agent guidance to list Python 3.14
- Add a changie entry

## Important compatibility note
This PR prepares Fabric CLI for Python 3.14, but dependency-resolved installation on Python 3.14 is still blocked by the published `fabric-cicd` releases, which currently declare `Requires-Python <3.14`.

The remaining blocker is tracked in microsoft/fabric-cicd#868, with companion PR microsoft/fabric-cicd#1050 opened for the `fabric-cicd` metadata update. A compatible `fabric-cicd` release will be needed before `pip install ms-fabric-cli` can fully resolve dependencies on Python 3.14.

## Validation
- `python3 -c "import pathlib, tomllib; data=tomllib.loads(pathlib.Path('pyproject.toml').read_text()); print(data['project']['requires-python']); print([d for d in data['project']['dependencies'] if d.startswith('msal') or d.startswith('fabric-cicd')])"`
- `python3 -m pip download msal==1.35.0 --no-deps -d /private/tmp/msal_135_py314_check`
- `python3 -m pip install -e . --no-deps --target /private/tmp/fabric_cli_py314_install_test2`
- `uv run --with ruff ruff check README.md docs/index.md AGENTS.md pyproject.toml`
- `uv run --with ruff ruff format --check pyproject.toml`

Full dependency installation was also checked on Python 3.14 and currently fails because `fabric-cicd>=0.3.1` has no published Python 3.14-compatible release yet.
