### PR TITLE
feat: add --use-device-code flag to auth login

### DIFF
--- a/.changes/unreleased/added-20260630-223439.yaml
+++ b/.changes/unreleased/added-20260630-223439.yaml
@@ -1,0 +1,6 @@
+kind: added
+body: Add ``--use-device-code`` flag to ``auth login`` for device code authentication flow
+time: 2026-06-30T22:34:39.210039642+02:00
+custom:
+    Author: iemejia
+    AuthorLink: https://github.com/iemejia

--- a/src/fabric_cli/commands/auth/fab_auth.py
+++ b/src/fabric_cli/commands/auth/fab_auth.py
@@ -16,6 +16,7 @@ from fabric_cli.utils import fab_ui, fab_version_check
 def init(args: Namespace) -> Any:
     auth_options = [
         "Interactive with a web browser",
+        "Device code",
         "Service principal authentication with secret",
         "Service principal authentication with certificate",
         "Service principal authentication with federated credential",
@@ -27,7 +28,15 @@ def init(args: Namespace) -> Any:
     # Clean up stale context files when logging in
     Context().cleanup_context_files(cleanup_all_stale=True, cleanup_current=False)
 
-    if args.identity:
+    if args.use_device_code:
+        FabAuth().set_access_mode("user", args.tenant)
+        with FabAuth().device_code_flow():
+            FabAuth().get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
+            FabAuth().get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
+            FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
+        Context().context = FabAuth().get_tenant()
+
+    elif args.identity:
         FabAuth().set_access_mode("managed_identity")
         FabAuth().set_managed_identity(args.username)
         FabAuth().get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
@@ -72,6 +81,13 @@ def init(args: Namespace) -> Any:
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
+                Context().context = FabAuth().get_tenant()
+            elif selected_auth == "Device code":
+                FabAuth().set_access_mode("user", args.tenant)
+                with FabAuth().device_code_flow():
+                    FabAuth().get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
+                    FabAuth().get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
+                    FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
                 Context().context = FabAuth().get_tenant()
             elif selected_auth.startswith("Service principal authentication"):
                 fab_logger.log_warning(

--- a/src/fabric_cli/commands/auth/fab_auth.py
+++ b/src/fabric_cli/commands/auth/fab_auth.py
@@ -29,12 +29,13 @@ def init(args: Namespace) -> Any:
     Context().cleanup_context_files(cleanup_all_stale=True, cleanup_current=False)
 
     if args.use_device_code:
-        FabAuth().set_access_mode("user", args.tenant)
-        with FabAuth().device_code_flow():
-            FabAuth().get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
-            FabAuth().get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
-            FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
-        Context().context = FabAuth().get_tenant()
+        auth = FabAuth()
+        auth.set_access_mode("user", args.tenant)
+        with auth.device_code_flow():
+            auth.get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
+            auth.get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
+            auth.get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
+        Context().context = auth.get_tenant()
 
     elif args.identity:
         FabAuth().set_access_mode("managed_identity")
@@ -83,12 +84,13 @@ def init(args: Namespace) -> Any:
                 FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
                 Context().context = FabAuth().get_tenant()
             elif selected_auth == "Device code":
-                FabAuth().set_access_mode("user", args.tenant)
-                with FabAuth().device_code_flow():
-                    FabAuth().get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
-                    FabAuth().get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
-                    FabAuth().get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
-                Context().context = FabAuth().get_tenant()
+                auth = FabAuth()
+                auth.set_access_mode("user", args.tenant)
+                with auth.device_code_flow():
+                    auth.get_access_token(scope=fab_constant.SCOPE_FABRIC_DEFAULT)
+                    auth.get_access_token(scope=fab_constant.SCOPE_ONELAKE_DEFAULT)
+                    auth.get_access_token(scope=fab_constant.SCOPE_AZURE_DEFAULT)
+                Context().context = auth.get_tenant()
             elif selected_auth.startswith("Service principal authentication"):
                 fab_logger.log_warning(
                     "Ensure tenant setting is enabled for Service Principal auth"

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -66,8 +66,9 @@ class FabAuth:
         an exception occurs.
 
         Usage:
-            with FabAuth().device_code_flow():
-                FabAuth().get_access_token(scope=...)
+            auth = FabAuth()
+            with auth.device_code_flow():
+                auth.get_access_token(scope=...)
         """
         self._use_device_code = True
         try:
@@ -290,7 +291,7 @@ class FabAuth:
                 )
         return self.app
 
-    def _acquire_token_by_device_code(self, scope: list[str]) -> Optional[dict]:
+    def _acquire_token_by_device_code(self, scopes: list[str]) -> Optional[dict]:
         """
         Acquire a token using the device code flow.
 
@@ -301,25 +302,28 @@ class FabAuth:
         first to avoid prompting the user multiple times for different scopes.
 
         Args:
-            scope: The scopes for which to request the token
+            scopes: The scopes for which to request the token
 
         Returns:
             Full MSAL result dictionary containing access_token, expires_on, etc.,
-            or None if the device flow returns no result.        Raises:
+            or None if the device flow returns no result.
+
+        Raises:
             FabricCLIError: When device code flow initiation or token acquisition fails
         """
         # If we already have an account from a prior device code auth in this
         # session, try silent acquisition with force_refresh to use the refresh
         # token for a different resource scope.
-        accounts = self._get_app().get_accounts()
+        app = self._get_app()
+        accounts = app.get_accounts()
         if accounts:
-            token = self._get_app().acquire_token_silent(
-                scopes=scope, account=accounts[0], force_refresh=True
+            token = app.acquire_token_silent(
+                scopes=scopes, account=accounts[0], force_refresh=True
             )
             if token and token.get("access_token"):
                 return token
 
-        flow = self._get_app().initiate_device_flow(scopes=scope)
+        flow = app.initiate_device_flow(scopes=scopes)
         if "user_code" not in flow:
             raise FabricCLIError(
                 ErrorMessages.Auth.device_code_flow_failed(
@@ -332,7 +336,7 @@ class FabAuth:
         utils_ui.print_grey(flow["message"])
 
         # Wait for the user to authenticate
-        token = self._get_app().acquire_token_by_device_flow(flow)
+        token = app.acquire_token_by_device_flow(flow)
         return token
 
     def _get_access_token_from_env_vars_if_exist(self, scope):
@@ -571,7 +575,9 @@ class FabAuth:
                     if token is not None and "id_token_claims" in token:
                         id_token_claims = token.get("id_token_claims")
                         if id_token_claims:
-                            self.set_tenant(id_token_claims["tid"])
+                            tid = id_token_claims.get("tid")
+                            if tid:
+                                self.set_tenant(tid)
 
             if token and token.get("error"):
                 fab_logger.log_debug(

--- a/src/fabric_cli/core/fab_auth.py
+++ b/src/fabric_cli/core/fab_auth.py
@@ -5,6 +5,7 @@ import json
 import os
 import uuid
 from binascii import hexlify
+from contextlib import contextmanager
 from typing import Any, NamedTuple, Optional
 
 import jwt
@@ -50,10 +51,29 @@ class FabAuth:
         # Reset the auth info
         self.app: msal.ClientApplication = None
         self._auth_info = {}
+        self._use_device_code = False
 
         # Load the auth info and environment variables
         self._load_auth()
         self._load_env()
+
+    @contextmanager
+    def device_code_flow(self):
+        """Context manager to enable device code authentication flow.
+
+        Temporarily enables device code flow for token acquisition within
+        the context block. Automatically resets the flag on exit, even if
+        an exception occurs.
+
+        Usage:
+            with FabAuth().device_code_flow():
+                FabAuth().get_access_token(scope=...)
+        """
+        self._use_device_code = True
+        try:
+            yield
+        finally:
+            self._use_device_code = False
 
     def _save_auth(self):
         from fabric_cli.utils.fab_secure_io import write_restricted_file
@@ -269,6 +289,51 @@ class FabAuth:
                     }
                 )
         return self.app
+
+    def _acquire_token_by_device_code(self, scope: list[str]) -> Optional[dict]:
+        """
+        Acquire a token using the device code flow.
+
+        This initiates a device code flow, prints the user code and verification
+        URL to the console, and waits for the user to complete authentication
+        on another device. If an account already exists in the cache (from a
+        prior device code flow in the same session), attempts a silent refresh
+        first to avoid prompting the user multiple times for different scopes.
+
+        Args:
+            scope: The scopes for which to request the token
+
+        Returns:
+            Full MSAL result dictionary containing access_token, expires_on, etc.,
+            or None if the device flow returns no result.        Raises:
+            FabricCLIError: When device code flow initiation or token acquisition fails
+        """
+        # If we already have an account from a prior device code auth in this
+        # session, try silent acquisition with force_refresh to use the refresh
+        # token for a different resource scope.
+        accounts = self._get_app().get_accounts()
+        if accounts:
+            token = self._get_app().acquire_token_silent(
+                scopes=scope, account=accounts[0], force_refresh=True
+            )
+            if token and token.get("access_token"):
+                return token
+
+        flow = self._get_app().initiate_device_flow(scopes=scope)
+        if "user_code" not in flow:
+            raise FabricCLIError(
+                ErrorMessages.Auth.device_code_flow_failed(
+                    flow.get("error_description", "Unknown error")
+                ),
+                con.ERROR_AUTHENTICATION_FAILED,
+            )
+
+        # Display the device code message to the user
+        utils_ui.print_grey(flow["message"])
+
+        # Wait for the user to authenticate
+        token = self._get_app().acquire_token_by_device_flow(flow)
+        return token
 
     def _get_access_token_from_env_vars_if_exist(self, scope):
         if "FAB_TOKEN" in os.environ and "FAB_TOKEN_ONELAKE" in os.environ:
@@ -494,14 +559,19 @@ class FabAuth:
                     scopes=scope, account=account
                 )
 
-                if token is None and interactive_renew:
-                    token = self._get_app().acquire_token_interactive(
-                        scopes=scope,
-                        prompt="select_account",
-                        parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
-                    )
+                if (token is None or token.get("error")) and interactive_renew:
+                    if self._use_device_code:
+                        token = self._acquire_token_by_device_code(scope)
+                    else:
+                        token = self._get_app().acquire_token_interactive(
+                            scopes=scope,
+                            prompt="select_account",
+                            parent_window_handle=msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE,
+                        )
                     if token is not None and "id_token_claims" in token:
-                        self.set_tenant(token.get("id_token_claims")["tid"])
+                        id_token_claims = token.get("id_token_claims")
+                        if id_token_claims:
+                            self.set_tenant(id_token_claims["tid"])
 
             if token and token.get("error"):
                 fab_logger.log_debug(

--- a/src/fabric_cli/errors/auth.py
+++ b/src/fabric_cli/errors/auth.py
@@ -119,3 +119,7 @@ class AuthErrors:
     @staticmethod
     def only_supported_with_user_authentication() -> str:
         return "This operation is only supported with user authentication"
+
+    @staticmethod
+    def device_code_flow_failed(error_description: str) -> str:
+        return f"Failed to initiate device code flow: {error_description}"

--- a/src/fabric_cli/parsers/fab_auth_parser.py
+++ b/src/fabric_cli/parsers/fab_auth_parser.py
@@ -30,6 +30,8 @@ def register_parser(subparsers: _SubParsersAction) -> None:
         "$ auth login\n",
         "# command_line mode",
         "$ fab auth login\n",
+        "# command_line mode using device code auth",
+        "$ fab auth login --use-device-code\n",
         "# command_line mode using service principal auth",
         "$ fab auth login -u <client_id> -p <client_secret> --tenant <tenant_id>\n",
         "# command_line mode using system assigned managed identity auth",
@@ -84,9 +86,15 @@ def register_parser(subparsers: _SubParsersAction) -> None:
         required=False,
         help="Federated token that can be used for OIDC token exchange. Optional, only for service principal auth",
     )
+    login_parser.add_argument(
+        "--use-device-code",
+        required=False,
+        action="store_true",
+        help="Use device code authentication flow. Useful when browser access is not available.",
+    )
 
     login_parser.usage = f"{utils_error_parser.get_usage_prog(login_parser)}"
-    login_parser.set_defaults(func=lazy_command(_auth_module_path, 'init'))
+    login_parser.set_defaults(func=lazy_command(_auth_module_path, "init"))
 
     # Subcommand for 'logout'
     logout_examples = [
@@ -104,7 +112,7 @@ def register_parser(subparsers: _SubParsersAction) -> None:
     )
 
     logout_parser.usage = f"{utils_error_parser.get_usage_prog(logout_parser)}"
-    logout_parser.set_defaults(func=lazy_command(_auth_module_path, 'logout'))
+    logout_parser.set_defaults(func=lazy_command(_auth_module_path, "logout"))
 
     # Subcommand for 'status'
     status_examples = [
@@ -121,7 +129,7 @@ def register_parser(subparsers: _SubParsersAction) -> None:
     )
 
     status_parser.usage = f"{utils_error_parser.get_usage_prog(status_parser)}"
-    status_parser.set_defaults(func=lazy_command(_auth_module_path, 'status'))
+    status_parser.set_defaults(func=lazy_command(_auth_module_path, "status"))
 
 
 def show_help(args: Namespace) -> None:

--- a/tests/test_commands/test_auth.py
+++ b/tests/test_commands/test_auth.py
@@ -811,6 +811,155 @@ class TestAuth:
             name="Unknown", id="mocked_tenant_id"
         )
 
+    def test_init_with_device_code_auth_command_line(
+        self, mock_fab_auth, mock_fab_context
+    ):
+        # Arrange
+        args = prepare_auth_args({"use_device_code": True})
+
+        # Act
+        result = fab_auth.init(args)
+
+        # Assert
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.set_access_mode.assert_called_with("user", None)
+        assert_get_access_token(mock_fab_auth_instance)
+        assert result is True
+
+        assert_fab_context(mock_fab_context)
+
+    def test_init_with_device_code_auth_command_line_with_tenant(
+        self, mock_fab_auth, mock_fab_context
+    ):
+        # Arrange
+        args = prepare_auth_args({"use_device_code": True, "tenant": "mock_tenant"})
+
+        # Act
+        result = fab_auth.init(args)
+
+        # Assert
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.set_access_mode.assert_called_with("user", "mock_tenant")
+        assert_get_access_token(mock_fab_auth_instance)
+        assert result is True
+
+        assert_fab_context(mock_fab_context)
+
+    def test_init_with_device_code_auth_interactive(
+        self, mock_fab_auth, mock_fab_context
+    ):
+        # Arrange
+        with patch(
+            "fabric_cli.utils.fab_ui.prompt_select_item",
+            return_value="Device code",
+        ):
+            args = prepare_auth_args()
+
+            # Act
+            result = fab_auth.init(args)
+
+            # Assert
+            mock_fab_auth_instance = mock_fab_auth.get("instance")
+            mock_fab_auth_instance.set_access_mode.assert_called_with("user", None)
+            assert_get_access_token(mock_fab_auth_instance)
+            assert result is True
+
+            assert_fab_context(mock_fab_context)
+
+    def test_init_with_device_code_takes_precedence_over_identity(
+        self, mock_fab_auth, mock_fab_context
+    ):
+        """When both --use-device-code and --identity are passed, device code wins."""
+        # Arrange
+        args = prepare_auth_args({"use_device_code": True, "identity": True})
+
+        # Act
+        result = fab_auth.init(args)
+
+        # Assert: device code path was taken (set_access_mode("user")), not managed identity
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.set_access_mode.assert_called_with("user", None)
+        mock_fab_auth_instance.set_managed_identity.assert_not_called()
+        assert_get_access_token(mock_fab_auth_instance)
+        assert result is True
+
+        assert_fab_context(mock_fab_context)
+
+    def test_init_with_device_code_takes_precedence_over_spn_args(
+        self, mock_fab_auth, mock_fab_context
+    ):
+        """When --use-device-code is passed alongside -u/-p, device code wins."""
+        # Arrange
+        args = prepare_auth_args(
+            {
+                "use_device_code": True,
+                "username": "some_client_id",
+                "password": "some_secret",
+                "tenant": "some_tenant",
+            }
+        )
+
+        # Act
+        result = fab_auth.init(args)
+
+        # Assert: device code path was taken, not SPN
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.set_access_mode.assert_called_with("user", "some_tenant")
+        mock_fab_auth_instance.set_spn.assert_not_called()
+        assert_get_access_token(mock_fab_auth_instance)
+        assert result is True
+
+        assert_fab_context(mock_fab_context)
+
+    def test_init_with_device_code_resets_flag_on_success(
+        self, mock_fab_auth, mock_fab_context
+    ):
+        """Verify _use_device_code flag is reset to False after successful login."""
+        # Arrange
+        args = prepare_auth_args({"use_device_code": True})
+
+        # Act
+        fab_auth.init(args)
+
+        # Assert: flag should be reset
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        assert mock_fab_auth_instance._use_device_code is False
+
+    def test_init_with_device_code_resets_flag_on_exception(self, mock_fab_auth):
+        """Verify _use_device_code flag is reset even when get_access_token raises."""
+        # Arrange
+        mock_fab_auth_instance = mock_fab_auth.get("instance")
+        mock_fab_auth_instance.get_access_token.side_effect = FabricCLIError(
+            "Token acquisition failed",
+            fab_constant.ERROR_AUTHENTICATION_FAILED,
+        )
+        args = prepare_auth_args({"use_device_code": True})
+
+        # Act
+        with pytest.raises(FabricCLIError):
+            fab_auth.init(args)
+
+        # Assert: flag should be reset thanks to try/finally
+        assert mock_fab_auth_instance._use_device_code is False
+
+    def test_init_with_device_code_interactive_resets_flag_on_success(
+        self, mock_fab_auth, mock_fab_context
+    ):
+        """Verify _use_device_code flag is reset after interactive device code login."""
+        # Arrange
+        with patch(
+            "fabric_cli.utils.fab_ui.prompt_select_item",
+            return_value="Device code",
+        ):
+            args = prepare_auth_args()
+
+            # Act
+            fab_auth.init(args)
+
+            # Assert: flag should be reset
+            mock_fab_auth_instance = mock_fab_auth.get("instance")
+            assert mock_fab_auth_instance._use_device_code is False
+
     def test_init_with_args_auth_missing_arg_raise_exception(self):
         # Test without tenant
         # Arrange
@@ -821,6 +970,7 @@ class TestAuth:
             identity=None,
             certificate=None,
             federated_token=None,
+            use_device_code=None,
         )
 
         # Act
@@ -837,6 +987,7 @@ class TestAuth:
             identity=None,
             certificate=None,
             federated_token=None,
+            use_device_code=None,
         )
 
         # Act
@@ -853,6 +1004,7 @@ class TestAuth:
             identity=None,
             certificate=None,
             federated_token=None,
+            use_device_code=None,
         )
 
         # Act
@@ -971,6 +1123,7 @@ def prepare_auth_args(args=None):
                 "identity",
                 "certificate",
                 "federated_token",
+                "use_device_code",
             ]
         }
     )

--- a/tests/test_core/test_fab_auth.py
+++ b/tests/test_core/test_fab_auth.py
@@ -875,11 +875,7 @@ def test_get_access_token_token_error(monkeypatch):
     with pytest.raises(FabricCLIError) as exc_info:
         auth.get_access_token(["dummy_scope"])
     assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
-    assert (
-        exc_info.value.message
-        == ErrorMessages.Auth.token_acquisition_failed()
-    )
-    assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
+    assert exc_info.value.message == ErrorMessages.Auth.token_acquisition_failed()
 
 
 def test_set_access_mode_success(monkeypatch):
@@ -1168,6 +1164,488 @@ def test_save_auth_tightens_permissions_on_existing_file_success(tmp_path):
     with open(auth.auth_file, "r") as f:
         data = json.load(f)
     assert data[con.IDENTITY_TYPE] == "spn"
+
+
+# endregion
+
+
+# region device code flow tests
+
+
+def test_acquire_token_by_device_code_success(monkeypatch):
+    """Verify device code flow acquires token successfully when no cached account."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+
+    mock_flow = {
+        "user_code": "ABC123",
+        "message": "To sign in, use a web browser to open https://microsoft.com/devicelogin and enter the code ABC123",
+        "device_code": "device_code_value",
+    }
+    mock_token = {
+        "access_token": "mocked_device_code_token",
+        "id_token_claims": {"tid": "mock_tenant_id"},
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey") as mock_print,
+    ):
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.return_value = mock_token
+
+        result = auth._acquire_token_by_device_code(con.SCOPE_FABRIC_DEFAULT)
+
+        mock_app.return_value.initiate_device_flow.assert_called_once_with(
+            scopes=con.SCOPE_FABRIC_DEFAULT
+        )
+        mock_print.assert_called_once_with(mock_flow["message"])
+        mock_app.return_value.acquire_token_by_device_flow.assert_called_once_with(
+            mock_flow
+        )
+        assert result == mock_token
+
+
+def test_acquire_token_by_device_code_silent_refresh_for_subsequent_scopes(
+    monkeypatch,
+):
+    """Verify device code uses silent refresh when account already exists in cache."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+
+    cached_account = {"username": "user@test.com"}
+    silent_token = {
+        "access_token": "silently_refreshed_token",
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey") as mock_print,
+    ):
+        mock_app.return_value.get_accounts.return_value = [cached_account]
+        mock_app.return_value.acquire_token_silent.return_value = silent_token
+
+        result = auth._acquire_token_by_device_code(con.SCOPE_ONELAKE_DEFAULT)
+
+        # Should use silent refresh, NOT initiate a new device code flow
+        mock_app.return_value.acquire_token_silent.assert_called_once_with(
+            scopes=con.SCOPE_ONELAKE_DEFAULT,
+            account=cached_account,
+            force_refresh=True,
+        )
+        mock_app.return_value.initiate_device_flow.assert_not_called()
+        mock_app.return_value.acquire_token_by_device_flow.assert_not_called()
+        mock_print.assert_not_called()
+        assert result == silent_token
+
+
+def test_acquire_token_by_device_code_falls_back_to_device_flow_when_silent_fails(
+    monkeypatch,
+):
+    """Verify device code falls back to full flow when silent refresh fails."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+
+    cached_account = {"username": "user@test.com"}
+    mock_flow = {
+        "user_code": "FALL01",
+        "message": "Go to https://microsoft.com/devicelogin and enter FALL01",
+        "device_code": "device_code_value",
+    }
+    mock_token = {
+        "access_token": "device_flow_token_after_silent_failure",
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey") as mock_print,
+    ):
+        mock_app.return_value.get_accounts.return_value = [cached_account]
+        # Silent returns error (no access_token)
+        mock_app.return_value.acquire_token_silent.return_value = {
+            "error": "interaction_required"
+        }
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.return_value = mock_token
+
+        result = auth._acquire_token_by_device_code(con.SCOPE_ONELAKE_DEFAULT)
+
+        # Silent was tried first
+        mock_app.return_value.acquire_token_silent.assert_called_once()
+        # Then fell back to device code flow
+        mock_app.return_value.initiate_device_flow.assert_called_once()
+        mock_print.assert_called_once_with(mock_flow["message"])
+        assert result == mock_token
+
+
+def test_acquire_token_by_device_code_falls_back_when_silent_returns_none(
+    monkeypatch,
+):
+    """Verify device code falls back to full flow when silent returns None."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+
+    cached_account = {"username": "user@test.com"}
+    mock_flow = {
+        "user_code": "NUL02",
+        "message": "Go to https://microsoft.com/devicelogin and enter NUL02",
+        "device_code": "device_code_value",
+    }
+    mock_token = {
+        "access_token": "device_flow_token_after_none",
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey") as mock_print,
+    ):
+        mock_app.return_value.get_accounts.return_value = [cached_account]
+        mock_app.return_value.acquire_token_silent.return_value = None
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.return_value = mock_token
+
+        result = auth._acquire_token_by_device_code(con.SCOPE_ONELAKE_DEFAULT)
+
+        mock_app.return_value.acquire_token_silent.assert_called_once()
+        mock_app.return_value.initiate_device_flow.assert_called_once()
+        assert result == mock_token
+
+
+def test_acquire_token_by_device_code_falls_back_when_silent_returns_null_access_token(
+    monkeypatch,
+):
+    """Verify device code falls back when silent returns access_token as None."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+
+    cached_account = {"username": "user@test.com"}
+    mock_flow = {
+        "user_code": "NUL03",
+        "message": "Go to https://microsoft.com/devicelogin and enter NUL03",
+        "device_code": "device_code_value",
+    }
+    mock_token = {
+        "access_token": "device_flow_token_after_null_access",
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey"),
+    ):
+        mock_app.return_value.get_accounts.return_value = [cached_account]
+        # Silent returns a dict with access_token key but None value
+        mock_app.return_value.acquire_token_silent.return_value = {
+            "access_token": None,
+            "error": "interaction_required",
+        }
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.return_value = mock_token
+
+        result = auth._acquire_token_by_device_code(con.SCOPE_ONELAKE_DEFAULT)
+
+        # Should NOT have short-circuited on the silent result
+        mock_app.return_value.initiate_device_flow.assert_called_once()
+        assert result == mock_token
+
+
+def test_acquire_token_by_device_code_initiation_failure(monkeypatch):
+    """Verify device code flow raises error when initiation fails."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+
+    mock_flow = {
+        "error": "authorization_pending",
+        "error_description": "Device code flow initiation failed",
+    }
+
+    with patch.object(auth, "_get_app") as mock_app:
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            auth._acquire_token_by_device_code(con.SCOPE_FABRIC_DEFAULT)
+
+        assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
+        assert "Device code flow initiation failed" in exc_info.value.message
+
+
+def test_acquire_token_uses_device_code_when_flag_set(monkeypatch):
+    """Verify acquire_token dispatches to device code flow when _use_device_code is True."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+    auth._use_device_code = True
+
+    mock_flow = {
+        "user_code": "XYZ789",
+        "message": "Go to https://microsoft.com/devicelogin and enter XYZ789",
+        "device_code": "device_code_value",
+    }
+    mock_token = {
+        "access_token": "device_code_access_token",
+        "id_token_claims": {"tid": "test_tenant"},
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey"),
+        patch.object(auth, "set_tenant"),
+        patch(
+            "fabric_cli.utils.fab_secure_io.restrict_existing_file",
+        ),
+    ):
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.acquire_token_silent.return_value = None
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.return_value = mock_token
+
+        result = auth.acquire_token(con.SCOPE_FABRIC_DEFAULT, interactive_renew=True)
+
+        mock_app.return_value.acquire_token_interactive.assert_not_called()
+        mock_app.return_value.initiate_device_flow.assert_called_once()
+        assert result["access_token"] == "device_code_access_token"
+
+    auth._use_device_code = False
+
+
+def test_acquire_token_uses_interactive_when_device_code_flag_not_set(monkeypatch):
+    """Verify acquire_token dispatches to interactive flow when _use_device_code is False."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+    auth._use_device_code = False
+
+    mock_token = {
+        "access_token": "interactive_access_token",
+        "id_token_claims": {"tid": "test_tenant"},
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch.object(auth, "set_tenant"),
+        patch(
+            "fabric_cli.utils.fab_secure_io.restrict_existing_file",
+        ),
+    ):
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.acquire_token_silent.return_value = None
+        mock_app.return_value.acquire_token_interactive.return_value = mock_token
+
+        result = auth.acquire_token(con.SCOPE_FABRIC_DEFAULT, interactive_renew=True)
+
+        mock_app.return_value.acquire_token_interactive.assert_called_once()
+        mock_app.return_value.initiate_device_flow.assert_not_called()
+        assert result["access_token"] == "interactive_access_token"
+
+
+def test_acquire_token_by_device_code_token_error(monkeypatch):
+    """Verify device code flow propagates token error through acquire_token error handling."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+    auth._use_device_code = True
+
+    mock_flow = {
+        "user_code": "ERR001",
+        "message": "Go to https://microsoft.com/devicelogin and enter ERR001",
+        "device_code": "device_code_value",
+    }
+    # MSAL returns error in the token result when auth fails (e.g. expired code)
+    mock_token = {
+        "error": "authorization_declined",
+        "error_description": "The user denied the authorization request",
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey"),
+        patch(
+            "fabric_cli.utils.fab_secure_io.restrict_existing_file",
+        ),
+    ):
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.acquire_token_silent.return_value = None
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.return_value = mock_token
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            auth.acquire_token(con.SCOPE_FABRIC_DEFAULT, interactive_renew=True)
+
+        assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
+
+    auth._use_device_code = False
+
+
+def test_acquire_token_by_device_code_returns_none(monkeypatch):
+    """Verify device code flow raises when acquire_token_by_device_flow returns None."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+    auth._use_device_code = True
+
+    mock_flow = {
+        "user_code": "NUL001",
+        "message": "Go to https://microsoft.com/devicelogin and enter NUL001",
+        "device_code": "device_code_value",
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey"),
+        patch(
+            "fabric_cli.utils.fab_secure_io.restrict_existing_file",
+        ),
+    ):
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.acquire_token_silent.return_value = None
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.return_value = None
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            auth.acquire_token(con.SCOPE_FABRIC_DEFAULT, interactive_renew=True)
+
+        assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
+
+    auth._use_device_code = False
+
+
+def test_acquire_token_by_device_code_no_access_token_in_result(monkeypatch):
+    """Verify device code flow raises when result has no access_token key."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+    auth._use_device_code = True
+
+    mock_flow = {
+        "user_code": "EMP001",
+        "message": "Go to https://microsoft.com/devicelogin and enter EMP001",
+        "device_code": "device_code_value",
+    }
+    # Token result with no access_token and no error
+    mock_token = {"some_other_key": "value"}
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey"),
+        patch(
+            "fabric_cli.utils.fab_secure_io.restrict_existing_file",
+        ),
+    ):
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.acquire_token_silent.return_value = None
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.return_value = mock_token
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            auth.acquire_token(con.SCOPE_FABRIC_DEFAULT, interactive_renew=True)
+
+        assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
+
+    auth._use_device_code = False
+
+
+def test_acquire_token_by_device_code_initiation_no_error_description(monkeypatch):
+    """Verify device code flow uses 'Unknown error' when no error_description present."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+
+    # Flow missing both user_code and error_description
+    mock_flow = {"error": "some_error"}
+
+    with patch.object(auth, "_get_app") as mock_app:
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+
+        with pytest.raises(FabricCLIError) as exc_info:
+            auth._acquire_token_by_device_code(con.SCOPE_FABRIC_DEFAULT)
+
+        assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
+        assert "Unknown error" in exc_info.value.message
+
+
+def test_acquire_token_by_device_code_keyboard_interrupt(monkeypatch):
+    """Verify KeyboardInterrupt during device flow wait propagates up."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+
+    mock_flow = {
+        "user_code": "INT001",
+        "message": "Go to https://microsoft.com/devicelogin and enter INT001",
+        "device_code": "device_code_value",
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch("fabric_cli.utils.fab_ui.print_grey"),
+    ):
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.initiate_device_flow.return_value = mock_flow
+        mock_app.return_value.acquire_token_by_device_flow.side_effect = (
+            KeyboardInterrupt()
+        )
+
+        with pytest.raises(KeyboardInterrupt):
+            auth._acquire_token_by_device_code(con.SCOPE_FABRIC_DEFAULT)
+
+
+def test_acquire_token_device_code_skipped_when_silent_succeeds(monkeypatch):
+    """Verify device code flow is NOT invoked when silent token acquisition succeeds."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+    auth._use_device_code = True
+
+    cached_token = {
+        "access_token": "cached_token_value",
+    }
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch(
+            "fabric_cli.utils.fab_secure_io.restrict_existing_file",
+        ),
+    ):
+        mock_app.return_value.get_accounts.return_value = [
+            {"username": "user@test.com"}
+        ]
+        mock_app.return_value.acquire_token_silent.return_value = cached_token
+
+        result = auth.acquire_token(con.SCOPE_FABRIC_DEFAULT, interactive_renew=True)
+
+        # Device code should NOT be initiated because silent succeeded
+        mock_app.return_value.initiate_device_flow.assert_not_called()
+        mock_app.return_value.acquire_token_by_device_flow.assert_not_called()
+        assert result["access_token"] == "cached_token_value"
+
+    auth._use_device_code = False
+
+
+def test_acquire_token_device_code_not_used_when_interactive_renew_false(monkeypatch):
+    """Verify device code flow is NOT invoked when interactive_renew=False."""
+    _clear_environment_variables(monkeypatch)
+    auth = FabAuth()
+    auth._auth_info = {con.IDENTITY_TYPE: "user"}
+    auth._use_device_code = True
+
+    with (
+        patch.object(auth, "_get_app") as mock_app,
+        patch(
+            "fabric_cli.utils.fab_secure_io.restrict_existing_file",
+        ),
+    ):
+        mock_app.return_value.get_accounts.return_value = []
+        mock_app.return_value.acquire_token_silent.return_value = None
+
+        # With interactive_renew=False, no interactive/device code should happen
+        with pytest.raises(FabricCLIError) as exc_info:
+            auth.acquire_token(con.SCOPE_FABRIC_DEFAULT, interactive_renew=False)
+
+        mock_app.return_value.initiate_device_flow.assert_not_called()
+        mock_app.return_value.acquire_token_by_device_flow.assert_not_called()
+        assert exc_info.value.status_code == con.ERROR_AUTHENTICATION_FAILED
+
+    auth._use_device_code = False
 
 
 # endregion


### PR DESCRIPTION
## Description

Add device code authentication flow for `fab auth login`, similar to `az login --use-device-code` in Azure CLI. This allows users to authenticate from environments where browser access is not available (SSH sessions, containers, remote servers, CI runners).

### Usage

```bash
fab auth login --use-device-code
fab auth login --use-device-code --tenant <tenant_id>
```

The option is also available in the interactive authentication menu as "Device code".

### Prerequisite: App registration change

The Fabric CLI app registration (5814bfb4-2705-4994-b8d6-39aabeb5eaeb) is configured as a confidential client. Device code flow requires "Allow public client flows" to be enabled:
- Azure Portal: App registrations > Authentication > Advanced settings > Allow public client flows > Yes
- Manifest: "allowPublicClient": true
 
### Implementation

- --use-device-code argument added to the auth login parser
- _acquire_token_by_device_code() method using MSAL's initiate_device_flow / acquire_token_by_device_flow
- Public FabAuth.device_code_flow() context manager to enable device code mode from the commands layer
- Silent refresh with force_refresh=True for subsequent scopes (user enters code only once)
- Fixed acquire_token_silent error handling: MSAL can return {"error": ...} (not just None)
Tests
- 8 command-level tests (CLI flag, tenant arg, interactive selection, precedence, flag cleanup)
- 11 core-level tests (success, silent refresh, fallbacks, error cases, KeyboardInterrupt)