### PR TITLE
Remove 'host-app/' prefix from User-Agent host app suffix

### DIFF
--- a/.changes/unreleased/fixed-20260706-165104.yaml
+++ b/.changes/unreleased/fixed-20260706-165104.yaml
@@ -1,0 +1,6 @@
+kind: fixed
+body: Remove invalid 'host-app/' prefix from User-Agent host app suffix
+time: 2026-07-06T16:51:04+03:00
+custom:
+    Author: KupoCat
+    AuthorLink: https://github.com/KupoCat

--- a/src/fabric_cli/client/fab_api_client.py
+++ b/src/fabric_cli/client/fab_api_client.py
@@ -297,7 +297,7 @@ def _build_user_agent(ctxt_cmd: str) -> str:
     """Build the User-Agent header for API requests.
 
     Example:
-        ms-fabric-cli/1.0.0 (create; Windows/10; Python/3.10.2) host-app/ado/2.0.0
+        ms-fabric-cli/1.0.0 (create; Windows/10; Python/3.10.2) ado/2.0.0
     """
     user_agent = (
         f"{fab_constant.API_USER_AGENT}/{fab_constant.FAB_VERSION} "
@@ -332,7 +332,7 @@ def _get_host_app() -> str:
     if not host_app_name:
         return ""
 
-    host_app = f" host-app/{host_app_name.lower()}"
+    host_app = f" {host_app_name.lower()}"
 
     # Check for optional version
     host_app_version = os.environ.get(fab_constant.FAB_HOST_APP_VERSION_ENV_VAR)

--- a/tests/test_core/test_fab_api_client.py
+++ b/tests/test_core/test_fab_api_client.py
@@ -316,17 +316,17 @@ def test_do_request_fabric_api_error_raised_on_failed_response(mock_get_token):
         (
             "Fabric-AzureDevops-Extension",
             None,
-            " host-app/fabric-azuredevops-extension",
+            " fabric-azuredevops-extension",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1.2.0",
-            " host-app/fabric-azuredevops-extension/1.2.0",
+            " fabric-azuredevops-extension/1.2.0",
         ),
         (
             "fabric-azuredevops-extension",
             "1.2.0",
-            " host-app/fabric-azuredevops-extension/1.2.0",
+            " fabric-azuredevops-extension/1.2.0",
         ),
         ("Invalid-App", "1.0.0", ""),
         ("", None, ""),
@@ -335,47 +335,47 @@ def test_do_request_fabric_api_error_raised_on_failed_response(mock_get_token):
         (
             "Fabric-AzureDevops-Extension",
             "1.2.0.4",  # Invalid format
-            " host-app/fabric-azuredevops-extension",
+            " fabric-azuredevops-extension",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1.2.a",  # Invalid format
-            " host-app/fabric-azuredevops-extension",
+            " fabric-azuredevops-extension",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "a.b.c",  # Invalid format
-            " host-app/fabric-azuredevops-extension",
+            " fabric-azuredevops-extension",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1",  # valid format
-            " host-app/fabric-azuredevops-extension/1",
+            " fabric-azuredevops-extension/1",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1.2",  # valid format
-            " host-app/fabric-azuredevops-extension/1.2",
+            " fabric-azuredevops-extension/1.2",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1.0.0",  # valid format
-            " host-app/fabric-azuredevops-extension/1.0.0",
+            " fabric-azuredevops-extension/1.0.0",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1.0.0-rc.1",  # valid format
-            " host-app/fabric-azuredevops-extension/1.0.0-rc.1",
+            " fabric-azuredevops-extension/1.0.0-rc.1",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1.0.0-alpha",  # valid format
-            " host-app/fabric-azuredevops-extension/1.0.0-alpha",
+            " fabric-azuredevops-extension/1.0.0-alpha",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1.0.0-beta",  # valid format
-            " host-app/fabric-azuredevops-extension/1.0.0-beta",
+            " fabric-azuredevops-extension/1.0.0-beta",
         ),
     ],
 )
@@ -416,12 +416,12 @@ def setup_default_private_links(mock_fab_set_state_config):
         (
             "Fabric-AzureDevops-Extension",
             None,
-            " host-app/fabric-azuredevops-extension",
+            " fabric-azuredevops-extension",
         ),
         (
             "Fabric-AzureDevops-Extension",
             "1.2.0",
-            " host-app/fabric-azuredevops-extension/1.2.0",
+            " fabric-azuredevops-extension/1.2.0",
         ),
         # Invalid app name - host-app suffix is omitted entirely from User-Agent
         ("Invalid-App", "1.0.0", ""),


### PR DESCRIPTION
## Motivation

When a host application is configured via environment variables, the CLI appends it to the User-Agent header in an invalid format: `host-app/[app-name]/version`. The `host-app/` prefix is not part of the intended User-Agent token format and should be removed.

## Approach

Removed the `host-app/` prefix from the string built in `_get_host_app()` so the suffix is now just the app name and optional version directly (e.g. `fabric-azuredevops-extension/1.2.0`).

Before: `ms-fabric-cli/1.0.0 (create; Windows/10; Python/3.10.2) host-app/fabric-azuredevops-extension/1.2.0`

After: `ms-fabric-cli/1.0.0 (create; Windows/10; Python/3.10.2) fabric-azuredevops-extension/1.2.0`

Updated all related test expectations to match the corrected format.