### PR TITLE
feat: support enable_shortcut_publish feature flag for deploy command

### DIFF
--- a/.changes/unreleased/added-20260710-000000.yaml
+++ b/.changes/unreleased/added-20260710-000000.yaml
@@ -1,0 +1,6 @@
+kind: added
+body: Adds the `--shortcut_publish` flag to the `deploy` command to deploy shortcuts with lakehouses
+time: 2026-07-10T00:00:00.000000+00:00
+custom:
+    Author: mprice-gcmlp
+    AuthorLink: https://github.com/mprice-gcmlp

--- a/docs/commands/fs/deploy.md
+++ b/docs/commands/fs/deploy.md
@@ -69,6 +69,25 @@ Notes:
 
 ---
 
+### Shortcut Publish
+
+By default, `deploy` does **not** deploy shortcuts (defined in `shortcuts.metadata.json`)
+together with their Lakehouse. You can optionally enable **shortcut publish** to include them.
+
+Enable it with the `--shortcut_publish` flag:
+
+```bash
+fab deploy --config config.yml --target_env dev --shortcut_publish
+```
+
+Notes:
+
+- This is an [optional feature](https://microsoft.github.io/fabric-cicd/latest/how_to/optional_feature/) of the underlying `fabric-cicd` library.
+- It is **disabled by default**, so existing deployments keep the standard publish behavior.
+- When enabled, the CLI turns on the `enable_shortcut_publish` fabric-cicd feature flag for you.
+
+---
+
 ### Configuration Behavior
 
 - The configuration file controls what is published and unpublished.

--- a/src/fabric_cli/commands/fs/deploy/fab_fs_deploy_config_file.py
+++ b/src/fabric_cli/commands/fs/deploy/fab_fs_deploy_config_file.py
@@ -32,6 +32,9 @@ def deploy_with_config_file(args: Namespace) -> None:
         # opt-in experimental bulk publish (single bulk import API call)
         _apply_bulk_publish_feature_flags(args)
 
+        # opt-in shortcut publish (deploy shortcuts with the lakehouse)
+        _apply_shortcut_publish_feature_flags(args)
+
         deploy_config_file = args.config
         deploy_parameters = get_dict_from_params(args.params, max_depth=1)
         for param in deploy_parameters:
@@ -77,3 +80,14 @@ def _apply_bulk_publish_feature_flags(args: Namespace) -> None:
             "fabric-cicd and may change or fail; omit the '--bulk_publish' flag "
             "to use standard per-item publish."
         )
+
+
+def _apply_shortcut_publish_feature_flags(args: Namespace) -> None:
+    """Enable fabric-cicd shortcut publish when the --shortcut_publish flag is set.
+
+    Shortcut publish deploys shortcuts together with their Lakehouse.
+    It is an opt-in fabric-cicd feature enabled via the 'enable_shortcut_publish'
+    feature flag. Disabled by default to preserve existing deploy behavior.
+    """
+    if getattr(args, "shortcut_publish", False):
+        append_feature_flag("enable_shortcut_publish")

--- a/src/fabric_cli/parsers/fab_fs_parser.py
+++ b/src/fabric_cli/parsers/fab_fs_parser.py
@@ -458,6 +458,8 @@ def register_deploy_parser(subparsers: _SubParsersAction) -> None:
         "$ deploy --config config.yml --target_env prod -P '[{\"param1\":\"value1\"}]' -f\n",
         "# deploy using experimental bulk publish (single bulk import API call)",
         "$ deploy --config config.yml --target_env dev --bulk_publish",
+        "# deploy including shortcuts with lakehouses",
+        "$ deploy --config config.yml --target_env dev --shortcut_publish",
     ]
 
     deploy_parser = subparsers.add_parser(
@@ -499,6 +501,13 @@ def register_deploy_parser(subparsers: _SubParsersAction) -> None:
         required=False,
         action="store_true",
         help="Experimental. Deploy all items in a single bulk import API call instead of one at a time. Optional",
+    )
+
+    deploy_parser.add_argument(
+        "--shortcut_publish",
+        required=False,
+        action="store_true",
+        help="Deploy shortcuts together with their Lakehouse. Optional",
     )
 
     deploy_parser.set_defaults(func=lazy_command(

--- a/tests/test_commands/recordings/test_commands/test_deploy/test_deploy_multiple_items_shortcut_publish_enabled_success.yaml
+++ b/tests/test_commands/recordings/test_commands/test_deploy/test_deploy_multiple_items_shortcut_publish_enabled_success.yaml
@@ -1,0 +1,3037 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:37 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 9030ea59-18c9-4005-91b8-02b18d040811
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:38 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 7945e84f-7368-47cb-a1a7-122d86fb84fd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:38 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 756a88e7-c934-48b5-83d7-b45a5b67416d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"displayName": "fabcli000001", "type": "DataPipeline", "folderId": null,
+      "description": "Created by fab-test"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/dataPipelines
+  response:
+    body:
+      string: '{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,ETag
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:43 GMT
+      ETag:
+      - '""'
+      Pragma:
+      - no-cache
+      RequestId:
+      - d4a5e433-f0b5-461e-99cd-5bf0aa5189cb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:44 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - c0ebc585-6209-49a1-8268-9685dcf790f4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:45 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - bafef9e0-5d74-4753-9cf2-5eaace5e8678
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/94fb3088-91d2-4fb6-840a-208495b1fa70
+  response:
+    body:
+      string: '{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,ETag
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:46 GMT
+      ETag:
+      - '""'
+      Pragma:
+      - no-cache
+      RequestId:
+      - b7bed300-ceb1-42b8-a4e4-564f40c7da8b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/94fb3088-91d2-4fb6-840a-208495b1fa70/getDefinition
+  response:
+    body:
+      string: '{"definition": {"parts": [{"path": "pipeline-content.json", "payload":
+        "ewogICJwcm9wZXJ0aWVzIjogewogICAgImFjdGl2aXRpZXMiOiBbXQogIH0KfQ==", "payloadType":
+        "InlineBase64"}, {"path": ".platform", "payload": "ewogICIkc2NoZW1hIjogImh0dHBzOi8vZGV2ZWxvcGVyLm1pY3Jvc29mdC5jb20vanNvbi1zY2hlbWFzL2ZhYnJpYy9naXRJbnRlZ3JhdGlvbi9wbGF0Zm9ybVByb3BlcnRpZXMvMi4wLjAvc2NoZW1hLmpzb24iLAogICJtZXRhZGF0YSI6IHsKICAgICJ0eXBlIjogIkRhdGFQaXBlbGluZSIsCiAgICAiZGlzcGxheU5hbWUiOiAiZmFiY2xpMDAwMDAxIiwKICAgICJkZXNjcmlwdGlvbiI6ICJDcmVhdGVkIGJ5IGZhYi10ZXN0IgogIH0sCiAgImNvbmZpZyI6IHsKICAgICJ2ZXJzaW9uIjogIjIuMCIsCiAgICAibG9naWNhbElkIjogIjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMCIKICB9Cn0=",
+        "payloadType": "InlineBase64"}]}}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '470'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:46 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 1c4edc21-4b98-4c95-a936-a5c91e4d4062
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:47 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - c9054603-2570-452d-a031-b0fbc587ac60
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:47 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 33f7dda9-559f-4452-b929-1ff627960e57
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:48 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 0783296c-e67e-4e5c-ba68-05d10b84f385
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"displayName": "fabcli000002", "type": "Notebook", "folderId": null, "description":
+      "Created by fab-test", "definition": {"parts": [{"path": "notebook-content.py",
+      "payload": "IyBGYWJyaWMgbm90ZWJvb2sgc291cmNlCgojIE1FVEFEQVRBICoqKioqKioqKioqKioqKioqKioqCgojIE1FVEEgewojIE1FVEEgICAia2VybmVsX2luZm8iOiB7CiMgTUVUQSAgICAgIm5hbWUiOiAic3luYXBzZV9weXNwYXJrIgojIE1FVEEgICB9LAojIE1FVEEgICAiZGVwZW5kZW5jaWVzIjoge30KIyBNRVRBIH0KCiMgQ0VMTCAqKioqKioqKioqKioqKioqKioqKgoKIyBXZWxjb21lIHRvIHlvdXIgbmV3IG5vdGVib29rCiMgVHlwZSBoZXJlIGluIHRoZSBjZWxsIGVkaXRvciB0byBhZGQgY29kZSEKCgojIE1FVEFEQVRBICoqKioqKioqKioqKioqKioqKioqCgojIE1FVEEgewojIE1FVEEgICAibGFuZ3VhZ2UiOiAicHl0aG9uIiwKIyBNRVRBICAgImxhbmd1YWdlX2dyb3VwIjogInN5bmFwc2VfcHlzcGFyayIKIyBNRVRBIH0K",
+      "payloadType": "InlineBase64"}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '769'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/notebooks
+  response:
+    body:
+      string: 'null'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,ETag,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:11:48 GMT
+      ETag:
+      - '""'
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/b0bd05de-f185-4b12-835e-c241e51d9fa6
+      Pragma:
+      - no-cache
+      RequestId:
+      - b2177967-e57a-446d-bd26-a8f3fe3a9d6d
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+      x-ms-operation-id:
+      - b0bd05de-f185-4b12-835e-c241e51d9fa6
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/b0bd05de-f185-4b12-835e-c241e51d9fa6
+  response:
+    body:
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-04-23T12:11:48.6155732",
+        "lastUpdatedTimeUtc": "2026-04-23T12:11:49.7678433", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:09 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/b0bd05de-f185-4b12-835e-c241e51d9fa6/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - 387fa34f-56cb-442a-b26d-324866edda82
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - b0bd05de-f185-4b12-835e-c241e51d9fa6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/b0bd05de-f185-4b12-835e-c241e51d9fa6/result
+  response:
+    body:
+      string: '{"id": "1ff62333-875f-476f-9e97-506f64f6bf15", "type": "Notebook",
+        "displayName": "fabcli000002", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Apr 2026 12:12:10 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 7cc3016e-d149-4479-973e-32e85152086d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:10 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 5bfb0d28-b27d-421b-9764-026416709792
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '235'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:11 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 8d4b6ea1-91da-417c-a461-90045ac70b0c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/1ff62333-875f-476f-9e97-506f64f6bf15
+  response:
+    body:
+      string: '{"id": "1ff62333-875f-476f-9e97-506f64f6bf15", "type": "Notebook",
+        "displayName": "fabcli000002", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,ETag
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '169'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:11 GMT
+      ETag:
+      - '""'
+      Pragma:
+      - no-cache
+      RequestId:
+      - 788cfd4a-c72d-414c-8bdc-039545ce4eef
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/1ff62333-875f-476f-9e97-506f64f6bf15/getDefinition?format=fabricGitSource
+  response:
+    body:
+      string: 'null'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:11 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/86db79ed-b70e-446b-9a42-ddbc0c1af606
+      Pragma:
+      - no-cache
+      RequestId:
+      - 82ee2ae8-c23e-4f9e-a754-7f832604edb7
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+      x-ms-operation-id:
+      - 86db79ed-b70e-446b-9a42-ddbc0c1af606
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/86db79ed-b70e-446b-9a42-ddbc0c1af606
+  response:
+    body:
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-04-23T12:12:12.0253071",
+        "lastUpdatedTimeUtc": "2026-04-23T12:12:12.8087043", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '129'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:32 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/86db79ed-b70e-446b-9a42-ddbc0c1af606/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - 0e1e8281-695c-4fbd-a071-b7d2bc4d477c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - 86db79ed-b70e-446b-9a42-ddbc0c1af606
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/86db79ed-b70e-446b-9a42-ddbc0c1af606/result
+  response:
+    body:
+      string: '{"definition": {"parts": [{"path": "notebook-content.py", "payload":
+        "IyBGYWJyaWMgbm90ZWJvb2sgc291cmNlCgojIE1FVEFEQVRBICoqKioqKioqKioqKioqKioqKioqCgojIE1FVEEgewojIE1FVEEgICAia2VybmVsX2luZm8iOiB7CiMgTUVUQSAgICAgIm5hbWUiOiAic3luYXBzZV9weXNwYXJrIgojIE1FVEEgICB9LAojIE1FVEEgICAiZGVwZW5kZW5jaWVzIjoge30KIyBNRVRBIH0KCiMgQ0VMTCAqKioqKioqKioqKioqKioqKioqKgoKIyBXZWxjb21lIHRvIHlvdXIgbmV3IG5vdGVib29rCiMgVHlwZSBoZXJlIGluIHRoZSBjZWxsIGVkaXRvciB0byBhZGQgY29kZSEKCgojIE1FVEFEQVRBICoqKioqKioqKioqKioqKioqKioqCgojIE1FVEEgewojIE1FVEEgICAibGFuZ3VhZ2UiOiAicHl0aG9uIiwKIyBNRVRBICAgImxhbmd1YWdlX2dyb3VwIjogInN5bmFwc2VfcHlzcGFyayIKIyBNRVRBIH0K",
+        "payloadType": "InlineBase64"}, {"path": ".platform", "payload": "ewogICIkc2NoZW1hIjogImh0dHBzOi8vZGV2ZWxvcGVyLm1pY3Jvc29mdC5jb20vanNvbi1zY2hlbWFzL2ZhYnJpYy9naXRJbnRlZ3JhdGlvbi9wbGF0Zm9ybVByb3BlcnRpZXMvMi4wLjAvc2NoZW1hLmpzb24iLAogICJtZXRhZGF0YSI6IHsKICAgICJ0eXBlIjogIk5vdGVib29rIiwKICAgICJkaXNwbGF5TmFtZSI6ICJmYWJjbGkwMDAwMDIiLAogICAgImRlc2NyaXB0aW9uIjogIkNyZWF0ZWQgYnkgZmFiLXRlc3QiCiAgfSwKICAiY29uZmlnIjogewogICAgInZlcnNpb24iOiAiMi4wIiwKICAgICJsb2dpY2FsSWQiOiAiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIgogIH0KfQ==",
+        "payloadType": "InlineBase64"}]}}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Apr 2026 12:12:33 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 6baf5098-660f-48bc-ad25-225800ebdb44
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:33 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 2b937185-e00a-47fe-849d-ca9566d954bf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '235'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:34 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 3db3e76e-27cd-48a8-8ad9-06869cc63903
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '235'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:34 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - e0fa353c-9339-4913-b4ec-dd71ac31e573
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"displayName": "fabcli000003", "type": "VariableLibrary", "folderId":
+      null, "description": "Created by fab-test"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/variablelibraries
+  response:
+    body:
+      string: '{"id": "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary",
+        "displayName": "fabcli000003", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,ETag
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:36 GMT
+      ETag:
+      - '""'
+      Pragma:
+      - no-cache
+      RequestId:
+      - e68b622a-67df-4607-a8c4-b20756f9f3b7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:36 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 2e105671-3aef-4c46-a768-67480f0745d8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id":
+        "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary", "displayName":
+        "fabcli000003", "description": "Created by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '284'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:37 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 89222b4f-786e-4482-ad69-b91db6a21935
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/7d76a1b3-ade2-4714-a204-be16c4562d17
+  response:
+    body:
+      string: '{"id": "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary",
+        "displayName": "fabcli000003", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,ETag
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:37 GMT
+      ETag:
+      - '""'
+      Pragma:
+      - no-cache
+      RequestId:
+      - 82c7fa62-2a51-4dc7-86ff-88aa71dc7b94
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/7d76a1b3-ade2-4714-a204-be16c4562d17/getDefinition
+  response:
+    body:
+      string: 'null'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:37 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6efbccd1-d024-462d-ab8d-98788eff2712
+      Pragma:
+      - no-cache
+      RequestId:
+      - b76878e7-ed22-46fd-8e4b-059740a0b51e
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+      x-ms-operation-id:
+      - 6efbccd1-d024-462d-ab8d-98788eff2712
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6efbccd1-d024-462d-ab8d-98788eff2712
+  response:
+    body:
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-04-23T12:12:38.2223549",
+        "lastUpdatedTimeUtc": "2026-04-23T12:12:38.5288067", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '130'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:12:58 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6efbccd1-d024-462d-ab8d-98788eff2712/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - 90d29e0d-0404-451f-b262-12039e5e33fe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - 6efbccd1-d024-462d-ab8d-98788eff2712
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/6efbccd1-d024-462d-ab8d-98788eff2712/result
+  response:
+    body:
+      string: '{"definition": {"parts": [{"path": "variables.json", "payload": "ew0KICAiJHNjaGVtYSI6ICJodHRwczovL2RldmVsb3Blci5taWNyb3NvZnQuY29tL2pzb24tc2NoZW1hcy9mYWJyaWMvaXRlbS92YXJpYWJsZUxpYnJhcnkvZGVmaW5pdGlvbi92YXJpYWJsZXMvMS4wLjAvc2NoZW1hLmpzb24iLA0KICAidmFyaWFibGVzIjogW10NCn0=",
+        "payloadType": "InlineBase64"}, {"path": "settings.json", "payload": "ew0KICAiJHNjaGVtYSI6ICJodHRwczovL2RldmVsb3Blci5taWNyb3NvZnQuY29tL2pzb24tc2NoZW1hcy9mYWJyaWMvaXRlbS92YXJpYWJsZUxpYnJhcnkvZGVmaW5pdGlvbi9zZXR0aW5ncy8xLjAuMC9zY2hlbWEuanNvbiIsDQogICJ2YWx1ZVNldHNPcmRlciI6IFtdDQp9",
+        "payloadType": "InlineBase64"}, {"path": ".platform", "payload": "ewogICIkc2NoZW1hIjogImh0dHBzOi8vZGV2ZWxvcGVyLm1pY3Jvc29mdC5jb20vanNvbi1zY2hlbWFzL2ZhYnJpYy9naXRJbnRlZ3JhdGlvbi9wbGF0Zm9ybVByb3BlcnRpZXMvMi4wLjAvc2NoZW1hLmpzb24iLAogICJtZXRhZGF0YSI6IHsKICAgICJ0eXBlIjogIlZhcmlhYmxlTGlicmFyeSIsCiAgICAiZGlzcGxheU5hbWUiOiAiZmFiY2xpMDAwMDAzIiwKICAgICJkZXNjcmlwdGlvbiI6ICJDcmVhdGVkIGJ5IGZhYi10ZXN0IgogIH0sCiAgImNvbmZpZyI6IHsKICAgICJ2ZXJzaW9uIjogIjIuMCIsCiAgICAibG9naWNhbElkIjogIjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMCIKICB9Cn0=",
+        "payloadType": "InlineBase64"}]}}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Apr 2026 12:12:59 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 71b9a361-12b6-4e94-9c72-38add6b84f23
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.powerbi.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "614b514b-15d8-423d-8df5-fb61aa05e3d1",
+        "displayName": "test1", "description": "", "type": "Workspace", "capacityId":
+        "00000000-0000-0000-0000-000000000004"}, {"id": "d4d535a0-bf24-42bb-9bc0-4992e5469535",
+        "displayName": "aviat", "description": "", "type": "Workspace", "capacityId":
+        "00000000-0000-0000-0000-000000000004"}, {"id": "d9a7f009-73b4-4c51-ac78-c621d4a54283",
+        "displayName": "Test [Workspace]", "description": "", "type": "Workspace",
+        "capacityId": "00000000-0000-0000-0000-000000000004"}, {"id": "e691a1c7-1100-426c-8518-fd666a7e7547",
+        "displayName": "[DEV]aviat", "description": "Created by fab", "type": "Workspace",
+        "capacityId": "00000000-0000-0000-0000-000000000004"}, {"id": "09f259f0-d280-454d-8769-7b119c2cb9b5",
+        "displayName": "Test Folders", "description": "", "type": "Workspace", "capacityId":
+        "00000000-0000-0000-0000-000000000004"}, {"id": "dac07cce-c498-4e25-93dc-5ffd53309bd4",
+        "displayName": "may", "description": "some description", "type": "Workspace",
+        "capacityId": "00000000-0000-0000-0000-000000000004"}, {"id": "e1e34046-97f7-4596-9d13-0fb4697a360c",
+        "displayName": "Test Folders Dest", "description": "", "type": "Workspace",
+        "capacityId": "00000000-0000-0000-0000-000000000004"}, {"id": "6b93fe30-2a71-44ae-8c8f-35a84441e26d",
+        "displayName": "Test_Folders", "description": "", "type": "Workspace", "capacityId":
+        "00000000-0000-0000-0000-000000000004"}, {"id": "7c6fc625-e060-4f3d-b6bf-210fb917b65b",
+        "displayName": "Test_Folders_Dest", "description": "", "type": "Workspace",
+        "capacityId": "00000000-0000-0000-0000-000000000004"}, {"id": "5c1706db-2a09-4051-abf0-7225e0dec6ec",
+        "displayName": "cp_test", "description": "", "type": "Workspace", "capacityId":
+        "00000000-0000-0000-0000-000000000004"}, {"id": "730bf543-1eeb-4a87-87c6-12be3a81561d",
+        "displayName": "cp_test_dest", "description": "", "type": "Workspace"}, {"id":
+        "e3ada810-2bdb-485a-a797-ecf2a44125b6", "displayName": "aviat_tmp", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "156f6968-d605-4437-92b0-dd386b2d601a", "displayName": "aviatWS", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "c180ed80-0904-493d-ae50-57cfb3f2dbfd", "displayName": "a1", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "f0c76c62-10ba-455d-8c4a-d8e5b5e71946", "displayName": "a2", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "c5ac0161-4d41-4bf5-a7c7-fda687e745f7", "displayName": "a3", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "51bfff37-d55e-4068-bf47-4fde9ab68c17", "displayName": "a13", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "bd1dd322-3bb0-4d25-9ef3-5b94e24b512e", "displayName": "a013", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "00b5fcad-c568-4e97-b4f1-99457ed7f996", "displayName": "fabclib7m90k8ztj''",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "ddcf3a35-834e-487e-a134-9d41f45f186e", "displayName": "fabclizsq1srrufe&",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "f6cb109d-d7cf-492b-84f3-78f99e6f6a14", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-24-08-27-57",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "4e23340e-e2c4-4476-a90c-fef2bc9a8e63", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-24-10-43-35",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "c8049371-5fb6-4498-b121-f29eca49b2a8", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-24-11-03-51",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "01e0a648-3cc0-4cde-a9a4-44d28bfba002", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-24-11-06-25",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "5b6c33d3-c54e-4aea-80ae-8d7472730f3f", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-24-11-10-47",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "3c880382-4bee-47ab-aeb3-63e9e9bf94fc", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-29-11-58-57",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "d3ac6290-8040-45dc-9390-c52f767e3fd7", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-29-12-14-16",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "b336c074-259a-4439-a533-0ea538f868f7", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-29-18-28-38",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "1474e5c1-07e7-4f4f-a057-0a573048c58d", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-30-09-57-31",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "a872f10c-f8ae-4ead-a539-bbf6b2f978fb", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-30-12-19-07",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "74fa2908-cb18-4600-8f17-87fd56c6e0ca", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-30-12-22-14",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "dfb8f1de-72fd-4be7-b9c5-0d6432e710b6"},
+        {"id": "eac80c84-67bf-4dd1-9efe-79481a51302a", "displayName": "fabriccli_WorkspacePerTestclass_2025-12-30-14-36-00",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "b987e586-60e2-4216-a025-60adf9e904ee", "displayName": "aviat-cli",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "20b99da1-4cd3-470e-9f08-eefcfdd0583a", "displayName": "cp_test_dest_2",
+        "description": "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "c1a769a2-cc1f-4c4b-b77c-019ab9a58f61", "displayName": "test ws with
+        ()", "description": "", "type": "Workspace", "capacityId": "dfb8f1de-72fd-4be7-b9c5-0d6432e710b6"},
+        {"id": "ec6a563a-f129-4c08-9a7f-316c8122fbdd", "displayName": "test_df", "description":
+        "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "d5585a92-e10d-4c1e-887a-cee677a5b827", "displayName": "fabcliamjzkr9qb2",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "e53f35e8-c92b-46df-8863-95873a367407", "displayName": "aviat_new",
+        "description": "", "type": "Workspace", "capacityId": "33e603a5-4fc2-4cb5-8a3f-b65dbf2a17e0"},
+        {"id": "b9e35731-6c52-4692-b7fa-09843fdfd4ef", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-09-14-46-20",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "985fdf75-95b0-43ba-aea9-c112e4a9c7a5", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-09-14-48-02",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "43dd025e-bb5a-44de-8af8-564cb6a3c63a", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-19-09-19-24",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "b8c06c2f-cbb7-4b16-be6c-382cd91ff11a", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-27-12-07-05",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "62aa677e-d451-47be-9622-06514b5d73ad", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-09-13-03",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "bd1115bc-af0c-49a4-9200-e176eefbca62", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-09-20-23",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "ae300895-e910-425a-a5d8-ab58a8daaffa", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-09-21-44",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "746a14ee-15ac-40db-8c73-668cd3dd1b4b", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-09-25-44",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "ba54d738-182a-4d50-b90c-839bce3c2497", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-09-29-44",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "0844bee9-7191-41aa-8f5f-184b8c68325a", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-09-36-02",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "99179029-5f5d-4e89-bb5b-5cdc71563a57", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-09-37-44",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "4ef2a64e-a4db-4ebe-91fb-89fb62b4cd9d", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-11-06-22",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "10c0a54d-7814-4ffe-a56a-5746a8218e10", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-30-12-37-16",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "321f00c7-7b03-48d1-af07-6f55250d248d", "displayName": "fabriccli_WorkspacePerTestclass_2026-03-31-08-32-05",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "d600124b-21bc-4ea7-aa61-2bbc0756a576", "displayName": "fabclipar0w8xouc",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "25f062d5-06e0-43ce-9b55-4c398b4084ce", "displayName": "fabcliu1z4uzjaon",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "ee3dee06-938d-4832-b0a9-35799aecc0b8", "displayName": "Fabric-CICD-E2E-Tests",
+        "description": "!!do not delete this workspace!![AlonY]", "type": "Workspace",
+        "capacityId": "00000000-0000-0000-0000-000000000004"}, {"id": "13e40a03-57fe-4cd4-8bf2-ec618e84220e",
+        "displayName": "fabriccli_WorkspacePerTestclass_2026-04-19-11-49-40", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "6f8a2821-f186-47b4-a76e-1b060e0c3fc6", "displayName": "ws1", "description":
+        "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "9783996b-f720-4ed2-8b66-47ff761edc33", "displayName": "fabriccli_WorkspacePerTestclass_2026-04-22-14-54-40",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "d98954b4-2ca2-40b7-a02d-f9859d901092", "displayName": "fabriccli_WorkspacePerTestclass_2026-04-22-17-51-40",
+        "description": "Created by fab", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "e41e2421-8902-47a6-bded-b2600aa3cd04", "displayName": "FabricCICD_FeatureBranch",
+        "description": "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "f100acef-79c5-4478-81b0-cc9156b91bf3", "displayName": "fabriccli_WorkspacePerTestclass_2026-04-23-11-55-11",
+        "description": "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"},
+        {"id": "e4f479cd-1e74-4479-bede-829ed8b44206", "displayName": "fabriccli_WorkspacePerTestclass_000001",
+        "description": "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:00 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - e97aab49-5b3e-44c9-8e44-edb573f5dbe9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206
+  response:
+    body:
+      string: '{"id": "e4f479cd-1e74-4479-bede-829ed8b44206", "displayName": "fabriccli_WorkspacePerTestclass_000001",
+        "description": "", "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004",
+        "capacityRegion": "Central US", "oneLakeEndpoints": {"blobEndpoint": "https://centralus-onelake.blob.fabric.microsoft.com",
+        "dfsEndpoint": "https://centralus-onelake.dfs.fabric.microsoft.com"}, "capacityAssignmentProgress":
+        "Completed"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '285'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:00 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - cdf50533-a739-4bda-957f-3957aae0ecb2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/folders
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:01 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 312cf999-0ca3-4519-a127-a39ba78e586c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id":
+        "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary", "displayName":
+        "fabcli000003", "description": "Created by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '284'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:01 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 846cd762-4d96-4c0e-a543-a035ac505282
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"definition": {"parts": [{"path": ".platform", "payload": "ewogICAgIiRzY2hlbWEiOiAiaHR0cHM6Ly9kZXZlbG9wZXIubWljcm9zb2Z0LmNvbS9qc29uLXNjaGVtYXMvZmFicmljL2dpdEludGVncmF0aW9uL3BsYXRmb3JtUHJvcGVydGllcy8yLjAuMC9zY2hlbWEuanNvbiIsCiAgICAibWV0YWRhdGEiOiB7CiAgICAgICAgInR5cGUiOiAiVmFyaWFibGVMaWJyYXJ5IiwKICAgICAgICAiZGlzcGxheU5hbWUiOiAiZmFiY2xpMDAwMDAzIiwKICAgICAgICAiZGVzY3JpcHRpb24iOiAiQ3JlYXRlZCBieSBmYWItdGVzdCIKICAgIH0sCiAgICAiY29uZmlnIjogewogICAgICAgICJ2ZXJzaW9uIjogIjIuMCIsCiAgICAgICAgImxvZ2ljYWxJZCI6ICIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiCiAgICB9Cn0=",
+      "payloadType": "InlineBase64"}, {"path": "variables.json", "payload": "ewogICAgIiRzY2hlbWEiOiAiaHR0cHM6Ly9kZXZlbG9wZXIubWljcm9zb2Z0LmNvbS9qc29uLXNjaGVtYXMvZmFicmljL2l0ZW0vdmFyaWFibGVMaWJyYXJ5L2RlZmluaXRpb24vdmFyaWFibGVzLzEuMC4wL3NjaGVtYS5qc29uIiwKICAgICJ2YXJpYWJsZXMiOiBbXQp9",
+      "payloadType": "InlineBase64"}, {"path": "settings.json", "payload": "ewogICAgIiRzY2hlbWEiOiAiaHR0cHM6Ly9kZXZlbG9wZXIubWljcm9zb2Z0LmNvbS9qc29uLXNjaGVtYXMvZmFicmljL2l0ZW0vdmFyaWFibGVMaWJyYXJ5L2RlZmluaXRpb24vc2V0dGluZ3MvMS4wLjAvc2NoZW1hLmpzb24iLAogICAgInZhbHVlU2V0c09yZGVyIjogW10KfQ==",
+      "payloadType": "InlineBase64"}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1167'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/7d76a1b3-ade2-4714-a204-be16c4562d17/updateDefinition?updateMetadata=True
+  response:
+    body:
+      string: 'null'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:02 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/e38018d4-0885-40b9-a500-84e7528143d3
+      Pragma:
+      - no-cache
+      RequestId:
+      - 7c962af1-23fe-465e-a349-0827c4445089
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+      x-ms-operation-id:
+      - e38018d4-0885-40b9-a500-84e7528143d3
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/e38018d4-0885-40b9-a500-84e7528143d3
+  response:
+    body:
+      string: '{"status": "Running", "createdTimeUtc": "2026-04-23T12:13:02.09672",
+        "lastUpdatedTimeUtc": "2026-04-23T12:13:02.09672", "percentComplete": null,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '119'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:02 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/e38018d4-0885-40b9-a500-84e7528143d3
+      Pragma:
+      - no-cache
+      RequestId:
+      - 8b6939f5-3b95-44ed-afc1-4f0c701bf4f4
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - e38018d4-0885-40b9-a500-84e7528143d3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/e38018d4-0885-40b9-a500-84e7528143d3
+  response:
+    body:
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-04-23T12:13:02.09672",
+        "lastUpdatedTimeUtc": "2026-04-23T12:13:04.461729", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '129'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:05 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/e38018d4-0885-40b9-a500-84e7528143d3/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - f2c9db59-7f09-4ac7-862a-e6487e679edb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - e38018d4-0885-40b9-a500-84e7528143d3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/e38018d4-0885-40b9-a500-84e7528143d3/result
+  response:
+    body:
+      string: '{"id": "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary",
+        "displayName": "fabcli000003", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Apr 2026 12:13:05 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 64bad76d-7487-4482-96b7-70ad42207826
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"activeValueSetName": "Default value set"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '59'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: PATCH
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/VariableLibraries/7d76a1b3-ade2-4714-a204-be16c4562d17
+  response:
+    body:
+      string: '{"id": "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary",
+        "displayName": "fabcli000003", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206", "properties": {"$type": "VariableLibraryProperties",
+        "activeValueSetName": "Default value set"}}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,ETag
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '221'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:06 GMT
+      ETag:
+      - '""'
+      Pragma:
+      - no-cache
+      RequestId:
+      - 496ccfbc-19ab-4ccc-a671-9a1ff8d1bede
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"definition": {"parts": [{"path": "notebook-content.py", "payload": "IyBGYWJyaWMgbm90ZWJvb2sgc291cmNlCgojIE1FVEFEQVRBICoqKioqKioqKioqKioqKioqKioqCgojIE1FVEEgewojIE1FVEEgICAia2VybmVsX2luZm8iOiB7CiMgTUVUQSAgICAgIm5hbWUiOiAic3luYXBzZV9weXNwYXJrIgojIE1FVEEgICB9LAojIE1FVEEgICAiZGVwZW5kZW5jaWVzIjoge30KIyBNRVRBIH0KCiMgQ0VMTCAqKioqKioqKioqKioqKioqKioqKgoKIyBXZWxjb21lIHRvIHlvdXIgbmV3IG5vdGVib29rCiMgVHlwZSBoZXJlIGluIHRoZSBjZWxsIGVkaXRvciB0byBhZGQgY29kZSEKCgojIE1FVEFEQVRBICoqKioqKioqKioqKioqKioqKioqCgojIE1FVEEgewojIE1FVEEgICAibGFuZ3VhZ2UiOiAicHl0aG9uIiwKIyBNRVRBICAgImxhbmd1YWdlX2dyb3VwIjogInN5bmFwc2VfcHlzcGFyayIKIyBNRVRBIH0K",
+      "payloadType": "InlineBase64"}, {"path": ".platform", "payload": "ewogICAgIiRzY2hlbWEiOiAiaHR0cHM6Ly9kZXZlbG9wZXIubWljcm9zb2Z0LmNvbS9qc29uLXNjaGVtYXMvZmFicmljL2dpdEludGVncmF0aW9uL3BsYXRmb3JtUHJvcGVydGllcy8yLjAuMC9zY2hlbWEuanNvbiIsCiAgICAibWV0YWRhdGEiOiB7CiAgICAgICAgInR5cGUiOiAiTm90ZWJvb2siLAogICAgICAgICJkaXNwbGF5TmFtZSI6ICJmYWJjbGkwMDAwMDIiLAogICAgICAgICJkZXNjcmlwdGlvbiI6ICJDcmVhdGVkIGJ5IGZhYi10ZXN0IgogICAgfSwKICAgICJjb25maWciOiB7CiAgICAgICAgInZlcnNpb24iOiAiMi4wIiwKICAgICAgICAibG9naWNhbElkIjogIjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMCIKICAgIH0KfQ==",
+      "payloadType": "InlineBase64"}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1227'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/1ff62333-875f-476f-9e97-506f64f6bf15/updateDefinition?updateMetadata=True
+  response:
+    body:
+      string: 'null'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,Retry-After,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:08 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/3418a874-1ac7-49f4-9212-31f17cf186d0
+      Pragma:
+      - no-cache
+      RequestId:
+      - 8889040a-ea65-4bba-83e4-c987dc5ccd9b
+      Retry-After:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+      x-ms-operation-id:
+      - 3418a874-1ac7-49f4-9212-31f17cf186d0
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/3418a874-1ac7-49f4-9212-31f17cf186d0
+  response:
+    body:
+      string: '{"status": "Succeeded", "createdTimeUtc": "2026-04-23T12:13:08.2972651",
+        "lastUpdatedTimeUtc": "2026-04-23T12:13:08.4661283", "percentComplete": 100,
+        "error": null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId,Location,x-ms-operation-id
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '130'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:09 GMT
+      Location:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/3418a874-1ac7-49f4-9212-31f17cf186d0/result
+      Pragma:
+      - no-cache
+      RequestId:
+      - ee060b2d-2e09-4c83-8d37-a7f11cd20e9a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      x-ms-operation-id:
+      - 3418a874-1ac7-49f4-9212-31f17cf186d0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://wabi-us-central-b-primary-redirect.analysis.windows.net/v1/operations/3418a874-1ac7-49f4-9212-31f17cf186d0/result
+  response:
+    body:
+      string: '{"id": "1ff62333-875f-476f-9e97-506f64f6bf15", "type": "Notebook",
+        "displayName": "fabcli000002", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Apr 2026 12:13:09 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 6f02f1c9-564b-4a05-9c09-dd2bf3a71cb6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id":
+        "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary", "displayName":
+        "fabcli000003", "description": "Created by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '284'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:11 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 40677365-7b24-4bb7-a6c6-ea92e5c052c3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"definition": {"parts": [{"path": "pipeline-content.json", "payload":
+      "ewogICAgInByb3BlcnRpZXMiOiB7CiAgICAgICAgImFjdGl2aXRpZXMiOiBbXQogICAgfQp9",
+      "payloadType": "InlineBase64"}, {"path": ".platform", "payload": "ewogICAgIiRzY2hlbWEiOiAiaHR0cHM6Ly9kZXZlbG9wZXIubWljcm9zb2Z0LmNvbS9qc29uLXNjaGVtYXMvZmFicmljL2dpdEludGVncmF0aW9uL3BsYXRmb3JtUHJvcGVydGllcy8yLjAuMC9zY2hlbWEuanNvbiIsCiAgICAibWV0YWRhdGEiOiB7CiAgICAgICAgInR5cGUiOiAiRGF0YVBpcGVsaW5lIiwKICAgICAgICAiZGlzcGxheU5hbWUiOiAiZmFiY2xpMDAwMDAxIiwKICAgICAgICAiZGVzY3JpcHRpb24iOiAiQ3JlYXRlZCBieSBmYWItdGVzdCIKICAgIH0sCiAgICAiY29uZmlnIjogewogICAgICAgICJ2ZXJzaW9uIjogIjIuMCIsCiAgICAgICAgImxvZ2ljYWxJZCI6ICIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiCiAgICB9Cn0=",
+      "payloadType": "InlineBase64"}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '753'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: POST
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/94fb3088-91d2-4fb6-840a-208495b1fa70/updateDefinition?updateMetadata=True
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 23 Apr 2026 12:13:12 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 1c4907e2-c456-45de-9d67-fcbf4379eec5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id":
+        "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary", "displayName":
+        "fabcli000003", "description": "Created by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '284'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:13 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - ca6264a5-c374-4e57-83c4-2ec40ce447fd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id":
+        "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary", "displayName":
+        "fabcli000003", "description": "Created by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '284'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:14 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - e51c9427-ffe1-4d16-8e71-d52125fd2aa7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.powerbi.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/folders
+  response:
+    body:
+      string: '{"value": []}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:15 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 0729dc87-99dc-42fd-8035-6676af4870da
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:15 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - b0cfff7e-ee8f-46cc-b724-6b8d71309576
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id":
+        "7d76a1b3-ade2-4714-a204-be16c4562d17", "type": "VariableLibrary", "displayName":
+        "fabcli000003", "description": "Created by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '284'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:15 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 6f65aed6-1f85-4cd0-b556-6974d1343d50
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: DELETE
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/7d76a1b3-ade2-4714-a204-be16c4562d17
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 23 Apr 2026 12:13:16 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - a4232b26-fe10-4319-ad8d-c6befda55e48
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:16 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - b04cb1e3-8afb-4578-af7c-7f3e658cc200
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}, {"id": "1ff62333-875f-476f-9e97-506f64f6bf15",
+        "type": "Notebook", "displayName": "fabcli000002", "description": "Created
+        by fab-test", "workspaceId": "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '235'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:17 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - d593ff99-8f05-401c-804f-c19af3743bd2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: DELETE
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/1ff62333-875f-476f-9e97-506f64f6bf15
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 23 Apr 2026 12:13:17 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 53a2f1bd-19ee-4afe-a42f-efa18b31ba78
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces
+  response:
+    body:
+      string: '{"value": [{"id": "3634a139-2c9e-4205-910b-3b089a31be47", "displayName":
+        "My workspace", "description": "", "type": "Personal"}, {"id": "e4f479cd-1e74-4479-bede-829ed8b44206",
+        "displayName": "fabriccli_WorkspacePerTestclass_000001", "description": "",
+        "type": "Workspace", "capacityId": "00000000-0000-0000-0000-000000000004"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2343'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:17 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - acc26f0c-0906-4258-9774-13ecd5f8f446
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: GET
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items
+  response:
+    body:
+      string: '{"value": [{"id": "94fb3088-91d2-4fb6-840a-208495b1fa70", "type": "DataPipeline",
+        "displayName": "fabcli000001", "description": "Created by fab-test", "workspaceId":
+        "e4f479cd-1e74-4479-bede-829ed8b44206"}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2026 12:13:17 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - d3953e90-cf44-4d80-a127-ce61ab6f5669
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ms-fabric-cli-test/1.5.0
+    method: DELETE
+    uri: https://api.fabric.microsoft.com/v1/workspaces/e4f479cd-1e74-4479-bede-829ed8b44206/items/94fb3088-91d2-4fb6-840a-208495b1fa70
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - RequestId
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 23 Apr 2026 12:13:19 GMT
+      Pragma:
+      - no-cache
+      RequestId:
+      - 49f3e14b-2704-4764-97e9-9a530dafc8b6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      home-cluster-uri:
+      - https://wabi-us-central-b-primary-redirect.analysis.windows.net/
+      request-redirected:
+      - 'true'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_commands/test_deploy.py
+++ b/tests/test_commands/test_deploy.py
@@ -113,6 +113,47 @@ class TestDeploy:
         assert "enable_experimental_features" in appended
         assert "enable_bulk_publish" in appended
 
+    def test_deploy_multiple_items_shortcut_publish_enabled_success(
+        self,
+        deploy_setup_factory,
+        cli_executor: CLIExecutor,
+        workspace,
+        mock_print_done,
+    ):
+        """
+        Test successful deployment of multiple items when the
+        --shortcut_publish flag is passed.
+
+        The test asserts the shortcut publish flag was appended before
+        invoking the mocked fabric-cicd deployment call.
+        """
+        import fabric_cli.commands.fs.deploy.fab_fs_deploy_config_file as deploy_mod
+
+        # Setup
+        deploy_config_path = deploy_setup_factory(
+            target_env="dev",
+            item_types=[ItemType.DATA_PIPELINE,
+                        ItemType.NOTEBOOK, ItemType.VARIABLE_LIBRARY]
+        )
+
+        mock_print_done.reset_mock()
+
+        with (
+            patch.object(deploy_mod, "append_feature_flag") as mock_flag,
+        ):
+            cli_executor.exec_command(
+                f"deploy --config {str(deploy_config_path)} --target_env dev --force --shortcut_publish")
+
+        # Assert deployment completed and the shortcut publish flag was applied
+        mock_print_done.assert_called()
+        assert "Deployment completed successfully" in str(
+            mock_print_done.call_args)
+        appended = [call.args[0] for call in mock_flag.call_args_list]
+        assert "disable_print_identity" in appended
+        assert "enable_shortcut_publish" in appended
+        # shortcut publish is not experimental and must not enable experimental mode
+        assert "enable_experimental_features" not in appended
+
     def test_deploy_config_without_tenv_with_prompt_success(
         self,
         deploy_setup_factory,

--- a/tests/test_utils/test_fab_deploy_shortcut_publish.py
+++ b/tests/test_utils/test_fab_deploy_shortcut_publish.py
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from unittest.mock import patch
+
+
+class TestDeployShortcutPublish:
+    """
+    Tests for the --shortcut_publish flag wiring into fabric-cicd feature flags.
+    These tests mock the fabric-cicd library so they do not require recorded
+    HTTP cassettes.
+    """
+
+    def _run_deploy(self, tmp_path, shortcut_publish, mock_fab_set_state_config):
+        """Invoke deploy_with_config_file with fabric-cicd mocked, returning the
+        append_feature_flag mock for assertions."""
+        from argparse import Namespace
+
+        import fabric_cli.commands.fs.deploy.fab_fs_deploy_config_file as deploy_mod
+        from fabric_cli.core import fab_constant
+
+        # disable debug mode so fabric-cicd file logging is disabled during the run
+        mock_fab_set_state_config(fab_constant.FAB_DEBUG_ENABLED, "false")
+
+        args = Namespace(
+            config=str(tmp_path / "config.yml"),
+            target_env="dev",
+            params=None,
+            shortcut_publish=shortcut_publish,
+        )
+
+        with (
+            patch.object(deploy_mod, "append_feature_flag") as mock_flag,
+            patch.object(deploy_mod, "deploy_with_config", return_value=None),
+            patch.object(deploy_mod, "disable_file_logging"),
+            patch.object(deploy_mod, "configure_external_file_logging"),
+            patch.object(
+                deploy_mod, "create_fabric_token_credential", return_value=None
+            ),
+        ):
+            deploy_mod.deploy_with_config_file(args)
+
+        return mock_flag
+
+    def test_deploy_shortcut_publish_enabled_appends_flag_success(
+        self, tmp_path, mock_fab_set_state_config
+    ):
+        """When --shortcut_publish is set, the shortcut publish feature flag is appended."""
+        mock_flag = self._run_deploy(tmp_path, True, mock_fab_set_state_config)
+
+        appended = [call.args[0] for call in mock_flag.call_args_list]
+        assert "enable_shortcut_publish" in appended
+        # shortcut publish is not experimental and must not enable experimental mode
+        assert "enable_experimental_features" not in appended
+        # existing behavior is preserved
+        assert "disable_print_identity" in appended
+
+    def test_deploy_shortcut_publish_disabled_by_default_omits_flag_success(
+        self, tmp_path, mock_fab_set_state_config
+    ):
+        """When --shortcut_publish is not set (default), the flag is not appended."""
+        mock_flag = self._run_deploy(tmp_path, False, mock_fab_set_state_config)
+
+        appended = [call.args[0] for call in mock_flag.call_args_list]
+        assert "enable_shortcut_publish" not in appended
+        # existing behavior is preserved
+        assert "disable_print_identity" in appended


### PR DESCRIPTION
## Summary

By default, fab deploy does not include shortcuts in the deployment of Lakehouses. There is a feature flag in fabric-cicd to allow this though. 

The feature is disabled by default, so existing deployments keep the standard per-item publish behavior. When enabled, the CLI turns on the feature flag being passed to fabric-cicd and will then deploy the shortcuts alongside the Lakehouse.

## Changes
New command flag: Added --shortcut_publish (if not provided, default is false).
Deploy behavior: deploy_with_config_file now calls _apply_shortcut_publish_feature_flags(args), which appends the enable_shortcut_publish  feature flag.