### PR TITLE
fix: handle HTTP 429 responses missing the Retry-After header

### DIFF
--- a/.changes/unreleased/fixed-20260716-092645.yaml
+++ b/.changes/unreleased/fixed-20260716-092645.yaml
@@ -1,0 +1,6 @@
+kind: fixed
+body: Handle HTTP 429 responses missing the Retry-After header instead of failing with an unexpected error
+time: 2026-07-16T09:26:45+03:00
+custom:
+    Author: ayeshurun
+    AuthorLink: https://github.com/ayeshurun

--- a/src/fabric_cli/client/fab_api_client.py
+++ b/src/fabric_cli/client/fab_api_client.py
@@ -188,7 +188,7 @@ def do_request(
                         fab_constant.ERROR_NOT_FOUND,
                     )
                 case 429:
-                    retry_after = int(response.headers["Retry-After"])
+                    retry_after = get_polling_interval(response.headers)
                     utils_ui.print_info(
                         f"Rate limit exceeded. {attempt}º retrying attemp in {retry_after} seconds"
                     )

--- a/tests/test_core/test_fab_api_client.py
+++ b/tests/test_core/test_fab_api_client.py
@@ -310,6 +310,41 @@ def test_do_request_fabric_api_error_raised_on_failed_response(mock_get_token):
         assert "ErrorCode" == excinfo.value.status_code
 
 
+@patch.object(FabAuth(), "get_access_token", return_value="dummy-token")
+def test_do_request_429_without_retry_after_header_retries_with_default_interval(
+    mock_get_token,
+):
+    """A 429 response missing the Retry-After header should fall back to the default
+    polling interval and retry instead of raising an unexpected KeyError."""
+
+    class DummyResponse:
+        def __init__(self, status_code, headers=None, text=""):
+            self.status_code = status_code
+            self.text = text
+            self.content = text.encode()
+            self.headers = headers if headers is not None else {}
+
+    # First response: throttled (429) with NO Retry-After header.
+    # Second response: success (200), so the retry loop can complete.
+    throttled = DummyResponse(429)
+    success = DummyResponse(200, text="{}")
+
+    dummy_args = Namespace()
+    dummy_args.uri = f"workspaces/{str(uuid.uuid4())}/items"
+    dummy_args.method = "get"
+    dummy_args.audience = None
+
+    with (
+        patch("requests.Session.request", side_effect=[throttled, success]),
+        patch("fabric_cli.client.fab_api_client.time.sleep") as mock_sleep,
+    ):
+        response = do_request(dummy_args, hostname="custom.hostname.com")
+
+    assert response.status_code == 200
+    # Retried using the default polling interval (10s) rather than raising.
+    mock_sleep.assert_called_once_with(10)
+
+
 @pytest.mark.parametrize(
     "host_app_env, host_app_version_env, expected_suffix",
     [


### PR DESCRIPTION
## ✨ Description of new changes

**Summary**: Long-running operations failing with `x [UnexpectedError] retry-after`.

**Context**: When Fabric throttles a request but returns an HTTP 429 **without** a `Retry-After` header, the rate-limit handler in `fab_api_client.py` read the header via direct subscript (`response.headers["Retry-After"]`). Because requests' `CaseInsensitiveDict` lowercases keys, this raised `KeyError("retry-after")`. That error was not caught by the `requests.RequestException` handler, so it bubbled up to `main.py` and surfaced as `[UnexpectedError] retry-after`. Creating a dataflow is a long-running, polling operation that is especially prone to hitting throttling, which is why it reproduced there.

The fix reuses the existing `get_polling_interval()` helper, which reads the `retry-after` header case-insensitively and falls back to the default polling interval (10s) when the header is missing or non-numeric. This makes the client resilient to throttled 429s and lets it retry as intended instead of erroring out.