### PR TITLE
fix: clean bulk_publish flags when deploy complete

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ argcomplete>=3.6.2
 psutil==7.0.0
 requests
 cryptography
-fabric-cicd>=1.2.0
+fabric-cicd>=1.3.0
 
 # Testing and Building Requirements
 tox>=4.20.0

--- a/src/fabric_cli/commands/fs/deploy/fab_fs_deploy_config_file.py
+++ b/src/fabric_cli/commands/fs/deploy/fab_fs_deploy_config_file.py
@@ -23,7 +23,6 @@ from fabric_cli.utils.fab_util import get_dict_from_params
 def deploy_with_config_file(args: Namespace) -> None:
     """deploy fabric items to a workspace using a configuration file and target environment - delegates to CICD library."""
 
-    bulk_publish_enabled = getattr(args, "bulk_publish", False)
     try:
         if fab_state_config.get_config(fab_constant.FAB_DEBUG_ENABLED) == "true":
             cli_logger = fab_logger.get_logger()
@@ -68,6 +67,7 @@ def deploy_with_config_file(args: Namespace) -> None:
             f"Deployment failed: {str(e)}", fab_constant.ERROR_IN_DEPLOYMENT
         )
     finally:
+        bulk_publish_enabled = getattr(args, "bulk_publish", False)
         if bulk_publish_enabled:
             _remove_bulk_publish_feature_flags()
 

--- a/src/fabric_cli/commands/fs/deploy/fab_fs_deploy_config_file.py
+++ b/src/fabric_cli/commands/fs/deploy/fab_fs_deploy_config_file.py
@@ -4,7 +4,13 @@
 import json
 from argparse import Namespace
 
-from fabric_cicd import append_feature_flag, configure_external_file_logging, deploy_with_config, disable_file_logging  # type: ignore
+from fabric_cicd import (  # type: ignore
+    append_feature_flag,
+    configure_external_file_logging,
+    deploy_with_config,
+    disable_file_logging,
+    remove_feature_flag,
+)
 
 from fabric_cli.core import fab_constant, fab_state_config
 from fabric_cli.core import fab_logger
@@ -17,6 +23,7 @@ from fabric_cli.utils.fab_util import get_dict_from_params
 def deploy_with_config_file(args: Namespace) -> None:
     """deploy fabric items to a workspace using a configuration file and target environment - delegates to CICD library."""
 
+    bulk_publish_enabled = getattr(args, "bulk_publish", False)
     try:
         if fab_state_config.get_config(fab_constant.FAB_DEBUG_ENABLED) == "true":
             cli_logger = fab_logger.get_logger()
@@ -37,8 +44,7 @@ def deploy_with_config_file(args: Namespace) -> None:
         for param in deploy_parameters:
             if isinstance(deploy_parameters[param], str):
                 try:
-                    deploy_parameters[param] = json.loads(
-                        deploy_parameters[param])
+                    deploy_parameters[param] = json.loads(deploy_parameters[param])
                 except json.JSONDecodeError:
                     # If it's not a valid JSON string, keep it as is
                     pass
@@ -51,17 +57,19 @@ def deploy_with_config_file(args: Namespace) -> None:
             config_file_path=deploy_config_file,
             environment=args.target_env,
             token_credential=create_fabric_token_credential(),  # MSAL bridge TokenCredential
-            **deploy_parameters
+            **deploy_parameters,
         )
 
         if result:
-            fab_ui.print_output_format(
-                args, message=result.message)
+            fab_ui.print_output_format(args, message=result.message)
 
     except Exception as e:
         raise FabricCLIError(
-            f"Deployment failed: {str(e)}",
-            fab_constant.ERROR_IN_DEPLOYMENT)
+            f"Deployment failed: {str(e)}", fab_constant.ERROR_IN_DEPLOYMENT
+        )
+    finally:
+        if bulk_publish_enabled:
+            _remove_bulk_publish_feature_flags()
 
 
 def _apply_bulk_publish_feature_flags(args: Namespace) -> None:
@@ -82,3 +90,9 @@ def _apply_bulk_publish_feature_flags(args: Namespace) -> None:
             "fabric-cicd and may change or fail; omit the '--bulk_publish' flag "
             "to use standard per-item publish."
         )
+
+
+def _remove_bulk_publish_feature_flags() -> None:
+    """Remove command-scoped bulk publish flags from fabric-cicd global state."""
+    remove_feature_flag("enable_experimental_features")
+    remove_feature_flag("enable_bulk_publish")

--- a/tests/test_utils/test_fab_deploy_bulk_publish.py
+++ b/tests/test_utils/test_fab_deploy_bulk_publish.py
@@ -13,7 +13,7 @@ class TestDeployBulkPublish:
 
     def _run_deploy(self, tmp_path, bulk_publish, mock_fab_set_state_config):
         """Invoke deploy_with_config_file with fabric-cicd mocked, returning the
-        append_feature_flag mock for assertions."""
+        feature flag mocks for assertions."""
         from argparse import Namespace
 
         import fabric_cli.commands.fs.deploy.fab_fs_deploy_config_file as deploy_mod
@@ -32,6 +32,7 @@ class TestDeployBulkPublish:
 
         with (
             patch.object(deploy_mod, "append_feature_flag") as mock_flag,
+            patch.object(deploy_mod, "remove_feature_flag") as mock_remove_flag,
             patch.object(deploy_mod, "deploy_with_config", return_value=None),
             patch.object(deploy_mod, "disable_file_logging"),
             patch.object(deploy_mod, "configure_external_file_logging"),
@@ -41,28 +42,35 @@ class TestDeployBulkPublish:
         ):
             deploy_mod.deploy_with_config_file(args)
 
-        return mock_flag
+        return mock_flag, mock_remove_flag
 
     def test_deploy_bulk_publish_enabled_appends_experimental_flags_success(
         self, tmp_path, mock_fab_set_state_config
     ):
         """When --bulk_publish is set, both experimental bulk publish flags are appended."""
-        mock_flag = self._run_deploy(tmp_path, True, mock_fab_set_state_config)
+        mock_flag, mock_remove_flag = self._run_deploy(
+            tmp_path, True, mock_fab_set_state_config
+        )
 
         appended = [call.args[0] for call in mock_flag.call_args_list]
         assert "enable_experimental_features" in appended
         assert "enable_bulk_publish" in appended
         # existing behavior is preserved
         assert "disable_print_identity" in appended
+        removed = [call.args[0] for call in mock_remove_flag.call_args_list]
+        assert removed == ["enable_experimental_features", "enable_bulk_publish"]
 
     def test_deploy_bulk_publish_disabled_by_default_omits_flags_success(
         self, tmp_path, mock_fab_set_state_config
     ):
-        """When --bulk_publish is not set (default), bulk publish flags are not appended."""
-        mock_flag = self._run_deploy(tmp_path, False, mock_fab_set_state_config)
+        """When --bulk_publish is not set, bulk publish flags are not changed."""
+        mock_flag, mock_remove_flag = self._run_deploy(
+            tmp_path, False, mock_fab_set_state_config
+        )
 
         appended = [call.args[0] for call in mock_flag.call_args_list]
         assert "enable_experimental_features" not in appended
         assert "enable_bulk_publish" not in appended
         # existing behavior is preserved
         assert "disable_print_identity" in appended
+        mock_remove_flag.assert_not_called()

--- a/tests/test_utils/test_fab_deploy_bulk_publish.py
+++ b/tests/test_utils/test_fab_deploy_bulk_publish.py
@@ -3,6 +3,10 @@
 
 from unittest.mock import patch
 
+import pytest
+
+from fabric_cli.core.fab_exceptions import FabricCLIError
+
 
 class TestDeployBulkPublish:
     """
@@ -11,24 +15,26 @@ class TestDeployBulkPublish:
     HTTP cassettes.
     """
 
-    def _run_deploy(self, tmp_path, bulk_publish, mock_fab_set_state_config):
-        """Invoke deploy_with_config_file with fabric-cicd mocked, returning the
-        feature flag mocks for assertions."""
+    def _create_deploy_args(self, tmp_path, bulk_publish):
+        """Create arguments for deploy_with_config_file."""
         from argparse import Namespace
 
-        import fabric_cli.commands.fs.deploy.fab_fs_deploy_config_file as deploy_mod
-        from fabric_cli.core import fab_constant
-
-        # disable debug mode so fabric-cicd file logging is disabled during the run
-        mock_fab_set_state_config(fab_constant.FAB_DEBUG_ENABLED, "false")
-
-        args = Namespace(
+        return Namespace(
             config=str(tmp_path / "config.yml"),
             target_env="dev",
             params=None,
             bulk_publish=bulk_publish,
             command_path="deploy",
         )
+
+    def _run_deploy_success(self, tmp_path, bulk_publish, mock_fab_set_state_config):
+        """Run a successful deployment and return feature flag mocks."""
+        import fabric_cli.commands.fs.deploy.fab_fs_deploy_config_file as deploy_mod
+        from fabric_cli.core import fab_constant
+
+        # disable debug mode so fabric-cicd file logging is disabled during the run
+        mock_fab_set_state_config(fab_constant.FAB_DEBUG_ENABLED, "false")
+        args = self._create_deploy_args(tmp_path, bulk_publish)
 
         with (
             patch.object(deploy_mod, "append_feature_flag") as mock_flag,
@@ -44,11 +50,39 @@ class TestDeployBulkPublish:
 
         return mock_flag, mock_remove_flag
 
+    def _run_deploy_failure(self, tmp_path, bulk_publish, mock_fab_set_state_config):
+        """Run a failed deployment and return feature flag mocks."""
+        import fabric_cli.commands.fs.deploy.fab_fs_deploy_config_file as deploy_mod
+        from fabric_cli.core import fab_constant
+
+        # disable debug mode so fabric-cicd file logging is disabled during the run
+        mock_fab_set_state_config(fab_constant.FAB_DEBUG_ENABLED, "false")
+        args = self._create_deploy_args(tmp_path, bulk_publish)
+
+        with (
+            patch.object(deploy_mod, "append_feature_flag") as mock_flag,
+            patch.object(deploy_mod, "remove_feature_flag") as mock_remove_flag,
+            patch.object(
+                deploy_mod,
+                "deploy_with_config",
+                side_effect=Exception("Simulated deployment failure"),
+            ),
+            patch.object(deploy_mod, "disable_file_logging"),
+            patch.object(deploy_mod, "configure_external_file_logging"),
+            patch.object(
+                deploy_mod, "create_fabric_token_credential", return_value=None
+            ),
+        ):
+            with pytest.raises(FabricCLIError):
+                deploy_mod.deploy_with_config_file(args)
+
+        return mock_flag, mock_remove_flag
+
     def test_deploy_bulk_publish_enabled_appends_experimental_flags_success(
         self, tmp_path, mock_fab_set_state_config
     ):
         """When --bulk_publish is set, both experimental bulk publish flags are appended."""
-        mock_flag, mock_remove_flag = self._run_deploy(
+        mock_flag, mock_remove_flag = self._run_deploy_success(
             tmp_path, True, mock_fab_set_state_config
         )
 
@@ -60,11 +94,22 @@ class TestDeployBulkPublish:
         removed = [call.args[0] for call in mock_remove_flag.call_args_list]
         assert removed == ["enable_experimental_features", "enable_bulk_publish"]
 
+    def test_deploy_bulk_publish_enabled_removes_flags_on_failure(
+        self, tmp_path, mock_fab_set_state_config
+    ):
+        """Bulk publish flags are removed when deployment raises an exception."""
+        _, mock_remove_flag = self._run_deploy_failure(
+            tmp_path, True, mock_fab_set_state_config
+        )
+
+        removed = [call.args[0] for call in mock_remove_flag.call_args_list]
+        assert removed == ["enable_experimental_features", "enable_bulk_publish"]
+
     def test_deploy_bulk_publish_disabled_by_default_omits_flags_success(
         self, tmp_path, mock_fab_set_state_config
     ):
         """When --bulk_publish is not set, bulk publish flags are not changed."""
-        mock_flag, mock_remove_flag = self._run_deploy(
+        mock_flag, mock_remove_flag = self._run_deploy_success(
             tmp_path, False, mock_fab_set_state_config
         )
 


### PR DESCRIPTION
This pull request improves the handling of the `--bulk_publish` feature flag during deployments and enhances test coverage to ensure correct behavior. The main changes include updating dependencies, ensuring feature flags are cleaned up after deployment, and adding tests to verify both the addition and removal of feature flags.

**Bulk publish feature flag management:**

* Ensured that when `--bulk_publish` is used, the corresponding feature flags (`enable_experimental_features` and `enable_bulk_publish`) are removed from global state after deployment by introducing the `_remove_bulk_publish_feature_flags` function and calling it in a `finally` block in `deploy_with_config_file`. [[1]](diffhunk://#diff-73cf2e64d00bd2eb88c72fbdabbb78a6344004948881fa919f5fc32fd6028e77L54-R72) [[2]](diffhunk://#diff-73cf2e64d00bd2eb88c72fbdabbb78a6344004948881fa919f5fc32fd6028e77R93-R98)
* Updated the import from `fabric_cicd` to include `remove_feature_flag`.

**Testing improvements:**

* Enhanced tests in `test_fab_deploy_bulk_publish.py` to verify that feature flags are correctly appended and removed when `--bulk_publish` is set, and that no removal occurs when it is not set. [[1]](diffhunk://#diff-ceca4f8997d9f814925721447d3b08650ec4dfe81aa7f9aef06d60489bca0110R35) [[2]](diffhunk://#diff-ceca4f8997d9f814925721447d3b08650ec4dfe81aa7f9aef06d60489bca0110L44-R76)
* Improved test helper method to return both append and remove feature flag mocks for assertions.

**Dependency updates:**

* Updated `fabric-cicd` dependency to version `>=1.3.0` in `requirements-dev.txt`.