### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/.changes/unreleased/added-20260417-105920.yaml
+++ b/.changes/unreleased/added-20260417-105920.yaml
@@ -1,6 +1,0 @@
-kind: added
-body: Adds support for environment definitions
-time: 2026-04-17T10:59:20.288002+03:00
-custom:
-    Author: v-alexmoraru
-    AuthorLink: https://github.com/v-alexmoraru

--- a/.changes/unreleased/added-20260512-150558.yaml
+++ b/.changes/unreleased/added-20260512-150558.yaml
@@ -1,6 +1,0 @@
-kind: added
-body: Return the job instance ID as a structured field in the JSON output of ``job run`` and ``job start`` commands
-time: 2026-05-12T15:05:58.3242491+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon

--- a/.changes/unreleased/added-20260625-145755.yaml
+++ b/.changes/unreleased/added-20260625-145755.yaml
@@ -1,6 +1,0 @@
-kind: added
-body: Support creating SQLDatabase with optional parameters. Support `creationMode` of type `New`, `Restore` and `RestoreDeletedDatabase`.
-time: 2026-06-25T14:57:55.03150683Z
-custom:
-    Author: aviatco
-    AuthorLink: https://github.com/aviatco

--- a/.changes/unreleased/added-20260701-121400.yaml
+++ b/.changes/unreleased/added-20260701-121400.yaml
@@ -1,6 +1,0 @@
-kind: added
-body: Adds the `--bulk_publish` flag to the `deploy` command to opt into experimental bulk publish
-time: 2026-07-01T12:14:00.000000+00:00
-custom:
-    Author: ayeshurun
-    AuthorLink: https://github.com/ayeshurun

--- a/.changes/unreleased/added-20260706-091126.yaml
+++ b/.changes/unreleased/added-20260706-091126.yaml
@@ -1,6 +1,0 @@
-kind: added
-body: Add new 'bulk-export' command for exporting workspace or folder items
-time: 2026-07-06T09:11:26.916814199Z
-custom:
-  Author: ohadedry
-  AuthorLink: https://github.com/ohadedry

--- a/.changes/unreleased/fixed-20260427-142055.yaml
+++ b/.changes/unreleased/fixed-20260427-142055.yaml
@@ -1,6 +1,0 @@
-kind: fixed
-body: Wraps long text on multiple lines
-time: 2026-04-27T14:20:55.3215682+03:00
-custom:
-    Author: v-alexmoraru
-    AuthorLink: https://github.com/v-alexmoraru

--- a/.changes/unreleased/fixed-20260607-134043.yaml
+++ b/.changes/unreleased/fixed-20260607-134043.yaml
@@ -1,6 +1,0 @@
-kind: fixed
-body: Restrict file and directory permissions on auth, config, context, and log paths to prevent local credential exposure on multi-user systems
-time: 2026-06-07T13:40:43+02:00
-custom:
-    Author: iemejia
-    AuthorLink: https://github.com/iemejia

--- a/.changes/unreleased/fixed-20260607-135834.yaml
+++ b/.changes/unreleased/fixed-20260607-135834.yaml
@@ -1,6 +1,0 @@
-kind: fixed
-body: Clean up temporary file after table maintenance job execution
-time: 2026-06-07T13:58:34+02:00
-custom:
-    Author: iemejia
-    AuthorLink: https://github.com/iemejia

--- a/.changes/unreleased/fixed-20260618-123845.yaml
+++ b/.changes/unreleased/fixed-20260618-123845.yaml
@@ -1,6 +1,0 @@
-kind: fixed
-body: Enforce owner-only permissions on local files on POSIX
-time: 2026-06-18T12:38:45Z
-custom:
-    Author: aviatcohen
-    AuthorLink: https://github.com/aviatcohen

--- a/.changes/unreleased/fixed-20260716-092645.yaml
+++ b/.changes/unreleased/fixed-20260716-092645.yaml
@@ -1,6 +1,0 @@
-kind: fixed
-body: Handle HTTP 429 responses missing the Retry-After header instead of failing with an unexpected error
-time: 2026-07-16T09:26:45+03:00
-custom:
-    Author: ayeshurun
-    AuthorLink: https://github.com/ayeshurun

--- a/.changes/unreleased/new-items-20260513-105250.yaml
+++ b/.changes/unreleased/new-items-20260513-105250.yaml
@@ -1,6 +1,0 @@
-kind: new-items
-body: Supports Digital Twin Builder Flow item
-time: 2026-05-13T10:52:50.730594+03:00
-custom:
-    Author: v-alexmoraru
-    AuthorLink: https://github.com/v-alexmoraru

--- a/.changes/v1.7.0.md
+++ b/.changes/v1.7.0.md
@@ -1,0 +1,22 @@
+## [v1.7.0](https://pypi.org/project/ms-fabric-cli/v1.7.0) - August 18, 2026
+
+### 🆕 New Items Support
+
+* Supports Digital Twin Builder Flow item by [v-alexmoraru](https://github.com/v-alexmoraru)
+
+### ✨ New Functionality
+
+* Adds support for environment definitions by [v-alexmoraru](https://github.com/v-alexmoraru)
+* Return the job instance ID as a structured field in the JSON output of ``job run`` and ``job start`` commands by [shirasassoon](https://github.com/shirasassoon)
+* Support creating SQLDatabase with optional parameters. Support `creationMode` of type `New`, `Restore` and `RestoreDeletedDatabase`. by [aviatco](https://github.com/aviatco)
+* Adds the `--bulk_publish` flag to the `deploy` command to opt into experimental bulk publish by [ayeshurun](https://github.com/ayeshurun)
+* Add new 'bulk-export' command for exporting workspace or folder items by [ohadedry](https://github.com/ohadedry)
+
+### 🔧 Bug Fix
+
+* Wraps long text on multiple lines by [v-alexmoraru](https://github.com/v-alexmoraru)
+* Restrict file and directory permissions on auth, config, context, and log paths to prevent local credential exposure on multi-user systems by [iemejia](https://github.com/iemejia)
+* Clean up temporary file after table maintenance job execution by [iemejia](https://github.com/iemejia)
+* Enforce owner-only permissions on local files on POSIX by [aviatcohen](https://github.com/aviatcohen)
+* Handle HTTP 429 responses missing the Retry-After header instead of failing with an unexpected error by [ayeshurun](https://github.com/ayeshurun)
+

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,29 @@ hide:
 # Release Notes
 
 
+## [v1.7.0](https://pypi.org/project/ms-fabric-cli/v1.7.0) - August 18, 2026
+
+### 🆕 New Items Support
+
+* Supports Digital Twin Builder Flow item by [v-alexmoraru](https://github.com/v-alexmoraru)
+
+### ✨ New Functionality
+
+* Adds support for environment definitions by [v-alexmoraru](https://github.com/v-alexmoraru)
+* Return the job instance ID as a structured field in the JSON output of ``job run`` and ``job start`` commands by [shirasassoon](https://github.com/shirasassoon)
+* Support creating SQLDatabase with optional parameters. Support `creationMode` of type `New`, `Restore` and `RestoreDeletedDatabase`. by [aviatco](https://github.com/aviatco)
+* Adds the `--bulk_publish` flag to the `deploy` command to opt into experimental bulk publish by [ayeshurun](https://github.com/ayeshurun)
+* Add new 'bulk-export' command for exporting workspace or folder items by [ohadedry](https://github.com/ohadedry)
+
+### 🔧 Bug Fix
+
+* Wraps long text on multiple lines by [v-alexmoraru](https://github.com/v-alexmoraru)
+* Restrict file and directory permissions on auth, config, context, and log paths to prevent local credential exposure on multi-user systems by [iemejia](https://github.com/iemejia)
+* Clean up temporary file after table maintenance job execution by [iemejia](https://github.com/iemejia)
+* Enforce owner-only permissions on local files on POSIX by [aviatcohen](https://github.com/aviatcohen)
+* Handle HTTP 429 responses missing the Retry-After header instead of failing with an unexpected error by [ayeshurun](https://github.com/ayeshurun)
+
+
 ## [v1.6.1](https://pypi.org/project/ms-fabric-cli/v1.6.1) - April 29, 2026
 
 ### 🆕 New Items Support
@@ -16,13 +39,13 @@ hide:
 ### ✨ New Functionality
 
 * Add new `fab find` command for searching the OneLake catalog across workspaces by [nschachter](https://github.com/nschachter)
-* Promote VariableLibrary from portal-only to full API support, enabling create, get, set, rm, ls, export, import, cp, and mv commands via the Variable Library REST APIs by [itsnotaboutthecell](https://github.com/itsnotaboutthecell)
+* Promote VariableLibrary from portal-only to full API support, enabling `create`, `get`, `set`, `rm`, `ls`, `export`, `import`, `cp`, and `mv` commands via the Variable Library REST APIs by [itsnotaboutthecell](https://github.com/itsnotaboutthecell)
 * adds hard flag to rm command (permanent delete) by [v-alexmoraru](https://github.com/v-alexmoraru)
 * supports lakehouse import & export by [v-alexmoraru](https://github.com/v-alexmoraru)
 
 ### 🔧 Bug Fix
 
-* Fix "caracters" typo in error message by [alonyeshurun](https://github.com/alonyeshurun)
+* fix correct "caracters" typo in error message by [alonyeshurun](https://github.com/alonyeshurun)
 * Remove hardcoded description when create/import items by [aviatco](https://github.com/aviatco)
 
 ### ⚡ Additional Optimizations

--- a/src/fabric_cli/__init__.py
+++ b/src/fabric_cli/__init__.py
@@ -2,4 +2,4 @@
 # Licensed under the MIT License.
 
 # Don't change this
-__version__ = "1.6.1"
+__version__ = "1.7.0"


### PR DESCRIPTION
## ✨ Description of new changes


## v1.7.0 - August 18, 2026

### 🆕 New Items Support

* Supports Digital Twin Builder Flow item by [v-alexmoraru](https://github.com/v-alexmoraru)

### ✨ New Functionality

* Adds support for environment definitions by [v-alexmoraru](https://github.com/v-alexmoraru)
* Return the job instance ID as a structured field in the JSON output of ``job run`` and ``job start`` commands by [shirasassoon](https://github.com/shirasassoon)
* Support creating SQLDatabase with optional parameters. Support `creationMode` of type `New`, `Restore` and `RestoreDeletedDatabase`. by [aviatco](https://github.com/aviatco)
* Adds the `--bulk_publish` flag to the `deploy` command to opt into experimental bulk publish by [ayeshurun](https://github.com/ayeshurun)
* Add new 'bulk-export' command for exporting workspace or folder items by [ohadedry](https://github.com/ohadedry)

### 🔧 Bug Fix

* Wraps long text on multiple lines by [v-alexmoraru](https://github.com/v-alexmoraru)
* Restrict file and directory permissions on auth, config, context, and log paths to prevent local credential exposure on multi-user systems by [iemejia](https://github.com/iemejia)
* Clean up temporary file after table maintenance job execution by [iemejia](https://github.com/iemejia)
* Enforce owner-only permissions on local files on POSIX by [aviatcohen](https://github.com/aviatcohen)
* Handle HTTP 429 responses missing the Retry-After header instead of failing with an unexpected error by [ayeshurun](https://github.com/ayeshurun)
