### PR TITLE
chore: FIx devcontainer python install issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM mcr.microsoft.com/devcontainers/python:3-3.12-bookworm
+
+ARG TARGETARCH
+
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        cmake \
+        libcairo2-dev \
+        pkg-config \
+        python3-dev \
+    && changie_version="1.26.0" \
+    && case "${TARGETARCH}" in \
+        amd64) changie_sha256="8586d01c321d3958bac72a7b3aeb29744b31bdabb06ffc65dbc4fb018a04f3d1" ;; \
+        arm64) changie_sha256="d31e2b7570e479fdebf43737458173ee9bdc90e3cd3d5aece0bf15a43a71eb50" ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && changie_deb="changie_${changie_version}_linux_${TARGETARCH}.deb" \
+    && curl -fsSL \
+        "https://github.com/miniscruff/changie/releases/download/v${changie_version}/${changie_deb}" \
+        -o "/tmp/${changie_deb}" \
+    && echo "${changie_sha256}  /tmp/${changie_deb}" | sha256sum -c - \
+    && apt-get install -y "/tmp/${changie_deb}" \
+    && rm -f "/tmp/${changie_deb}" \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,11 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
-		"ghcr.io/devcontainers/features/azure-cli:1": {},
-		"ghcr.io/devcontainers/features/node:2": {}
+		"ghcr.io/devcontainers/features/azure-cli:1": {}
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/local.env.example
+++ b/.devcontainer/local.env.example
@@ -1,0 +1,9 @@
+# Optional pip index override for the dev container setup script.
+#
+# Copy this file to `.devcontainer/local.env` and edit it. That path is
+# git-ignored so private mirror URLs are not committed accidentally.
+#
+#     cp .devcontainer/local.env.example .devcontainer/local.env
+#
+# Use this when the network requires an internal Python package mirror.
+# PIP_INDEX_URL=https://your-mirror.example.com/pypi/simple/

--- a/.gitignore
+++ b/.gitignore
@@ -209,4 +209,5 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
-devcontainer.local.json
+.devcontainer/local.env
+devcontainer-lock.json

--- a/scripts/install_dev_container_dependencies.sh
+++ b/scripts/install_dev_container_dependencies.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-apt-get update && apt-get install -y \
-    cmake \
-    libcairo2-dev \
-    pkg-config \
-    python3-dev
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
 
-pip3 install -r requirements-dev.txt -r requirements-docs.txt
+local_env="${repo_root}/.devcontainer/local.env"
+if [ -f "$local_env" ]; then
+    pip_index_url="$(sed -n 's/^PIP_INDEX_URL=//p' "$local_env" | tail -n 1)"
+    if [ -n "$pip_index_url" ]; then
+        export PIP_INDEX_URL="$pip_index_url"
+    fi
+fi
 
-npm install -g changie
+pip3 install -r "${repo_root}/requirements-dev.txt" -r "${repo_root}/requirements-docs.txt"


### PR DESCRIPTION
# 📥 Pull Request

The devcontainer previously relied on the base image's Python setup plus a separate npm-based `changie` install, which was failing dependency installation. This switches to a custom Dockerfile (pinned Python 3.12-bookworm) that installs build deps and `changie` via a verified `.deb` package instead of npm, removes the now-unneeded Node feature, and hardens `install_dev_container_dependencies.sh` (`set -euo pipefail`, absolute paths, optional `PIP_INDEX_URL` override via a git-ignored `local.env`) so dev container setup is reliable across environments, including restricted-network mirrors.

## Changes

- **`.devcontainer/devcontainer.json`**: Switched from a fixed base `image` to `build.dockerfile`, and removed the `node` feature (no longer needed since `changie` is installed via the Dockerfile).
- **`.devcontainer/local.env.example`** (new): Documents an optional `PIP_INDEX_URL` override for use with internal pip mirrors; copy to `.devcontainer/local.env` (git-ignored) to use.
- **`scripts/install_dev_container_dependencies.sh`**: Made executable; added `set -euo pipefail`; resolves paths relative to the repo root; sources `PIP_INDEX_URL` from `.devcontainer/local.env` if present; installs pip requirements only (apt packages and `changie` moved into the Dockerfile).
- **Base image**: Switched from `python:1-3.12-bullseye` (legacy tag format, Debian 11) to `python:3-3.12-bookworm` (current tag format, Debian 12), needed for a valid, maintained base to build the custom Dockerfile from.
